### PR TITLE
Fix wpcap dll mapping on linux

### DIFF
--- a/Pax.csproj
+++ b/Pax.csproj
@@ -26,6 +26,10 @@
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Paxifax.cs" />
     <Compile Include="Pax.cs" />
+    <None Include="lib/SharpPcap.dll.config">
+      <Link>SharpPcap.dll.config</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 <!--
   <Target Name="Build">

--- a/lib/SharpPcap.dll.config
+++ b/lib/SharpPcap.dll.config
@@ -1,4 +1,4 @@
 <configuration>
   <dllmap dll="wpcap.dll" target="libpcap.dylib" os="osx" />
-  <dllmap dll="wpcap.dll" target="libpcap.so" os="linux" />
+  <dllmap dll="wpcap" target="libpcap.so" os="linux" />
 </configuration>


### PR DESCRIPTION
The mapping provided in the SharpPcap repository ([here](https://github.com/chmorgan/sharppcap/blob/master/SharpPcap/SharpPcap.dll.config)) names the DLL as `wpcap`, not `wpcap.dll`, so I tried it out, and it works. No longer requires a local symlink of `libpcap.so` or anything else.

Not sure if a similar change is merited for `osx` or not.