### PR TITLE
Improve NAT and add testing with Mininet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+Bin/
+lib/
+!lib/SharpPcap.dll.config
+obj/
+*/obj/
+
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ obj/
 */obj/
 
 *.swp
+*.pyc

--- a/Pax.cs
+++ b/Pax.cs
@@ -109,7 +109,8 @@ namespace Pax
       Console.ResetColor();
 
       // FIXME accept a -j parameter to limit number of threads?
-      Parallel.ForEach(PaxConfig.deviceMap, device => device.Capture());
+      foreach (var device in PaxConfig.deviceMap)
+        device.StartCapture();
 
       // FIXME am i right in thinking that this location is unreachable, since the threads won't terminate unless the whole process is being terminated.
       return 0;
@@ -352,10 +353,11 @@ namespace Pax
     //Cleanup
     private static void shutdown (object sender, ConsoleCancelEventArgs args)
     {
-      for (int idx = 0; idx < PaxConfig.no_interfaces; idx++)
+      foreach (var device in PaxConfig.deviceMap)
       {
-        PaxConfig.deviceMap[idx].Close();
-      }
+        device.StopCaptureTimeout = TimeSpan.FromSeconds(1);
+        device.Close();
+      } 
 
       Console.ResetColor();
       Console.WriteLine ("Terminating");

--- a/Pax.cs
+++ b/Pax.cs
@@ -355,7 +355,11 @@ namespace Pax
     {
       foreach (var device in PaxConfig.deviceMap)
       {
+        // Set the capture timeout, as without the program can hang indefinitely.
+        // Cause unknown, but setting any timeout seems to fix it. Even with timeout
+        //  of 1s, the program shuts down immediately.
         device.StopCaptureTimeout = TimeSpan.FromSeconds(1);
+        
         device.Close();
       } 
 

--- a/Pax.cs
+++ b/Pax.cs
@@ -154,6 +154,7 @@ namespace Pax
 
       using (JsonTextReader r = new JsonTextReader(File.OpenText(PaxConfig.config_filename))) {
         JsonSerializer j = new JsonSerializer();
+        j.DefaultValueHandling = DefaultValueHandling.Populate;
         PaxConfig.configFile = j.Deserialize<ConfigFile>(r);
         PaxConfig.no_interfaces = PaxConfig.config.Count;
         PaxConfig.deviceMap = new ICaptureDevice[PaxConfig.no_interfaces];
@@ -185,7 +186,8 @@ namespace Pax
             {
               PaxConfig.deviceMap[idx] = device;
               PaxConfig.rdeviceMap.Add(device.Name, idx);
-              device.Open(DeviceMode.Normal, 100); // 100ms timeout
+              // Configure this device's read timeout
+              device.Open(DeviceMode.Normal, i.read_timeout);
 
               if (!String.IsNullOrEmpty(i.pcap_filter))
               {

--- a/Pax.cs
+++ b/Pax.cs
@@ -234,7 +234,7 @@ namespace Pax
           if ((!String.IsNullOrEmpty(PaxConfig.interface_lead_handler[idx])) &&
               type.Name == PaxConfig.interface_lead_handler[idx])
           {
-            // Only instatiate pp if needed
+            // Only instantiate pp if needed
             if (pp == null)
               pp = InstantiatePacketProcessor(type);
             if (pp == null)

--- a/Pax.cs
+++ b/Pax.cs
@@ -185,7 +185,7 @@ namespace Pax
             {
               PaxConfig.deviceMap[idx] = device;
               PaxConfig.rdeviceMap.Add(device.Name, idx);
-              device.Open();
+              device.Open(DeviceMode.Normal, 100); // 100ms timeout
 
               if (!String.IsNullOrEmpty(i.pcap_filter))
               {

--- a/Pax.cs
+++ b/Pax.cs
@@ -300,6 +300,19 @@ namespace Pax
       Console.ForegroundColor = ConsoleColor.Gray;
 
       // Set up callbacks.
+      Task.Factory.StartNew(() =>
+        {
+          while (true)
+          {
+            var key = Console.ReadKey();
+            // Shutdown on ^D
+            if ((key.Modifiers.HasFlag(ConsoleModifiers.Control) && key.Key == ConsoleKey.D)
+              || (int)key.KeyChar == 4)
+            {
+              shutdown(null, null);
+            }
+          }
+        });
       Console.CancelKeyPress += new ConsoleCancelEventHandler(shutdown);
       for (int idx = 0; idx < PaxConfig.no_interfaces; idx++)
       {

--- a/PaxConfig.cs
+++ b/PaxConfig.cs
@@ -37,6 +37,10 @@ namespace Pax
     // The function that is called when traffic arrives on this interface.
     public string lead_handler {get; set;}
 
+    // We use a default timeout of 100ms as a compromise between latency and performance
+    //  for flows with very few packets.
+    // The default SharpPcap timeout is 1000ms, which can cause problems when very few
+    //  packets are being sent, as they aren't processed in a timely enough manner.  
     [DefaultValue(100)]
     public int read_timeout { get; set; }
 

--- a/PaxConfig.cs
+++ b/PaxConfig.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Reflection;
 using SharpPcap;
 
@@ -35,6 +36,9 @@ namespace Pax
     public string interface_name {get; set;}
     // The function that is called when traffic arrives on this interface.
     public string lead_handler {get; set;}
+
+    [DefaultValue(100)]
+    public int read_timeout { get; set; }
 
     public IDictionary<string, string> environment {get; set;}
   }

--- a/PaxConfig.cs
+++ b/PaxConfig.cs
@@ -68,7 +68,7 @@ namespace Pax
     // FIXME better to link to function (rather than have indirection) to speed things up at runtime.
     // The file containing the catalogue of network interfaces.
     public static string config_filename;
-    // The assembly containing the packet handlers that the user wishess to use.
+    // The assembly containing the packet handlers that the user wishes to use.
     public static string assembly_filename;
     public static Assembly assembly;
 

--- a/Paxifax.cs
+++ b/Paxifax.cs
@@ -185,11 +185,14 @@ namespace Pax {
 #endif
       if (out_port > -1)
       {
-        PaxConfig.deviceMap[out_port].SendPacket(packet);
+        var device = PaxConfig.deviceMap[out_port];
+        if (packet is EthernetPacket)
+          ((EthernetPacket)packet).SourceHwAddress = device.MacAddress;
+        device.SendPacket(packet);
 #if DEBUG
         Debug.WriteLine(PaxConfig.deviceMap[out_port].Name);
       } else {
-        Debug.WriteLine("");
+        Debug.WriteLine("<dropped>");
 #endif
       }
     }

--- a/Paxifax.cs
+++ b/Paxifax.cs
@@ -124,7 +124,7 @@ namespace Pax {
             constructor.GetParameters()
                        .Select(p => ConvertConstructorParameter(p.ParameterType, argsDict[p.Name]))
                        .ToArray();
-          // Invoke the constructor, instatiating the type
+          // Invoke the constructor, instantiating the type
 #if MOREDEBUG
           Console.WriteLine("Invoking new {0}", ConstructorString(constructor, arguments));
 #endif

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ package. You might need to tweak Mono's config files (such as that in
 `/etc/mono/config`) in order to direct Mono's loader to the right location of
 libpcap on your system (by adding a
 [dllmap](http://www.mono-project.com/docs/advanced/pinvoke/dllmap/) entry).
-* **Optional** Mininet for [testing](https://github.com/niksu/pax/tree/master/examples#testing-the-nat-with-mininet). We used Mininet 2.2.1 on Ubuntu 14.04 LTS.
+* **Optional** Mininet for [testing](examples#testing-the-nat-with-mininet). We used Mininet 2.2.1 on Ubuntu 14.04 LTS.
 
 Put the DLLs for Newtonsoft.Json, SharpPcap and PacketDotNet in Pax's `lib/` directory.
 
@@ -49,7 +49,7 @@ This will produce a single file (Pax.exe), called an *assembly* in .NET jargon. 
 # Writing for Pax
 Packet processers using Pax can be written in any [.NET language](https://en.wikipedia.org/wiki/List_of_CLI_languages).
 They use Pax's API and define one or more functions that handle incoming packets.
-The [examples](https://github.com/niksu/pax/tree/master/examples) included with Pax could help get you going.
+The [examples](examples) included with Pax could help get you going.
 The workflow is as follows:
 
 1. Write your packet processors and use a .NET compiler to produce a DLL. Your DLL may contain multiple packet processors -- it is the *configuration file* that specifies which processor you wish you bind with which network interface.
@@ -78,7 +78,7 @@ Then Pax activates the handlers, and your code takes it from there.
 
 
 # What does a Pax processor look like?
-The main handler function of our [NAT example](https://github.com/niksu/pax/blob/master/examples/NAT.cs) looks like this.
+The main handler function of our [NAT example](examples/NAT.cs) looks like this.
 The return value is the port over which to emit the (modified) packet. The
 actual network interface connected to that port is determined by the
 configuration file.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ package. You might need to tweak Mono's config files (such as that in
 `/etc/mono/config`) in order to direct Mono's loader to the right location of
 libpcap on your system (by adding a
 [dllmap](http://www.mono-project.com/docs/advanced/pinvoke/dllmap/) entry).
+* **Optional** Mininet for [testing](https://github.com/niksu/pax/tree/master/examples#testing-the-nat-with-mininet). We used Mininet 2.2.1 on Ubuntu 14.04 LTS.
 
 Put the DLLs for Newtonsoft.Json, SharpPcap and PacketDotNet in Pax's `lib/` directory.
 

--- a/examples/NAT.cs
+++ b/examples/NAT.cs
@@ -47,10 +47,6 @@ public class NAT : SimplePacketProcessor {
   private readonly object portLock = new object();
   private readonly PhysicalAddress next_outside_hop_mac;
 
-  public NAT () {
-    // FIXME raise an exception if this constructor was used, since currently only the other constructor initialises things properly.
-  }
-
   public NAT (IPAddress my_address, ushort next_port, PhysicalAddress next_outside_hop_mac) {
     this.my_address = my_address;
     this.next_port = next_port;

--- a/examples/NAT.cs
+++ b/examples/NAT.cs
@@ -45,7 +45,7 @@ public class NAT : SimplePacketProcessor {
   private IPAddress my_address;
   private ushort next_port;
   private readonly object portLock = new object();
-  private readonly PhysicalAddress next_hop_mac;
+  private readonly PhysicalAddress next_outside_hop_mac;
 
   public NAT () {
     // FIXME raise an exception if this constructor was used, since currently only the other constructor initialises things properly.
@@ -54,7 +54,7 @@ public class NAT : SimplePacketProcessor {
   public NAT (IPAddress my_address, ushort next_port, PhysicalAddress next_hop_mac) {
     this.my_address = my_address;
     this.next_port = next_port;
-    this.next_hop_mac = next_hop_mac;
+    this.next_outside_hop_mac = next_hop_mac;
   }
 
   // We keep 2 dictionaries, one for queries related to packets crossing from the outside (O) to the inside (I), and
@@ -176,7 +176,7 @@ public class NAT : SimplePacketProcessor {
     ((IPv4Packet)p_ip).UpdateIPChecksum();
     p_tcp.UpdateTCPChecksum();
     // Update destination MAC address
-    p_eth.DestinationHwAddress = next_hop_mac;
+    p_eth.DestinationHwAddress = next_outside_hop_mac;
     return Port_Outside;
   }
 

--- a/examples/NAT.cs
+++ b/examples/NAT.cs
@@ -51,10 +51,10 @@ public class NAT : SimplePacketProcessor {
     // FIXME raise an exception if this constructor was used, since currently only the other constructor initialises things properly.
   }
 
-  public NAT (IPAddress my_address, ushort next_port, PhysicalAddress next_hop_mac) {
+  public NAT (IPAddress my_address, ushort next_port, PhysicalAddress next_outside_hop_mac) {
     this.my_address = my_address;
     this.next_port = next_port;
-    this.next_outside_hop_mac = next_hop_mac;
+    this.next_outside_hop_mac = next_outside_hop_mac;
   }
 
   // We keep 2 dictionaries, one for queries related to packets crossing from the outside (O) to the inside (I), and

--- a/examples/NAT.cs
+++ b/examples/NAT.cs
@@ -77,11 +77,11 @@ public class NAT : SimplePacketProcessor {
         IpPacket p_ip = ((IpPacket)(packet.PayloadPacket));
         TcpPacket p_tcp = ((PacketDotNet.TcpPacket)(p_ip.PayloadPacket));
 
-        #if DEBUG
+#if DEBUG
         Console.WriteLine("RX {0}:{1} -> {2}:{3} on {4} [{5}]",
           p_ip.SourceAddress, p_tcp.SourcePort, p_ip.DestinationAddress, p_tcp.DestinationPort, in_port,
           p_tcp.Syn?"S":"");
-        #endif
+#endif
 
         int out_port = Port_Drop;
         if (in_port == Port_Outside)
@@ -89,7 +89,7 @@ public class NAT : SimplePacketProcessor {
         else
           out_port = inside_to_outside (p_eth, p_ip, p_tcp, in_port);
 
-        #if DEBUG
+#if DEBUG
         Console.WriteLine(" (------ Outside ------)  \t<->\t (------ Inside ------) ");
         foreach (var entry in NAT_MapToInside)
         {
@@ -101,7 +101,7 @@ public class NAT : SimplePacketProcessor {
         {
           Console.WriteLine("{0} \t<->\t {1}", entry.Key, entry.Value);
         }
-        #endif
+#endif
 
         return out_port;
       }
@@ -200,9 +200,9 @@ public class NAT : SimplePacketProcessor {
     public int NetworkPort { get { return _NetworkPort; } }
     public PhysicalAddress MacAddress { get { return _MacAddress; } }
     private readonly int hashCode;
-    #if DEBUG
+#if DEBUG
     private string asString;
-    #endif
+#endif
 
     public InternalNode(IPAddress address, ushort port, int networkPort, PhysicalAddress macAddress)
     {
@@ -215,9 +215,9 @@ public class NAT : SimplePacketProcessor {
       _MacAddress = macAddress;
       // FIXME computing hash at construction relies on address being immutable (addr.Scope can change)
       hashCode = new { Address, Port, NetworkPort }.GetHashCode();
-      #if DEBUG
+#if DEBUG
       asString = this.ToString();
-      #endif
+#endif
     }
 
     public static bool operator ==(InternalNode a, InternalNode b)
@@ -246,11 +246,11 @@ public class NAT : SimplePacketProcessor {
     public override int GetHashCode() { return hashCode; }
     public override string ToString()
     {
-      #if DEBUG
+#if DEBUG
       if (asString != null)
         return asString;
       else
-      #endif
+#endif
       return String.Format("{0}:{1} at {2} on port {3}",
         Address.ToString(), Port.ToString(), MacAddress.ToString(), NetworkPort.ToString());
     }
@@ -263,9 +263,9 @@ public class NAT : SimplePacketProcessor {
     public ushort SourcePort { get { return _SourcePort; } }
     public ushort ArrivalPort { get { return _ArrivalPort; } }
     private readonly int hashCode;
-    #if DEBUG
+#if DEBUG
     private string asString;
-    #endif
+#endif
 
     public MapToInside_Key(IPAddress sourceAddress, ushort sourcePort, ushort arrivalPort)
     {
@@ -276,9 +276,9 @@ public class NAT : SimplePacketProcessor {
       _ArrivalPort = arrivalPort;
       // FIXME computing hash at construction relies on address being immutable (addr.Scope can change)
       hashCode = new { SourceAddress, SourcePort, ArrivalPort }.GetHashCode();
-      #if DEBUG
+#if DEBUG
       asString = this.ToString();
-      #endif
+#endif
     }
 
     public static bool operator ==(MapToInside_Key a, MapToInside_Key b)
@@ -306,11 +306,11 @@ public class NAT : SimplePacketProcessor {
     public override int GetHashCode() { return hashCode; }
     public override string ToString()
     {
-      #if DEBUG
+#if DEBUG
       if (asString != null)
         return asString;
       else
-      #endif
+#endif
       return SourceAddress.ToString() + ":" + SourcePort.ToString() + " to :" + ArrivalPort.ToString();
     }
   }
@@ -324,9 +324,9 @@ public class NAT : SimplePacketProcessor {
     public IPAddress DestinationAddress { get { return _DestinationAddress; } }
     public ushort DestinationPort { get { return _DestinationPort; } }
     private readonly int hashCode;
-    #if DEBUG
+#if DEBUG
     private string asString;
-    #endif
+#endif
 
     public MapToOutside_Key(IPAddress sourceAddress, ushort sourcePort,
                             IPAddress destinationAddress, ushort destinationPort)
@@ -340,9 +340,9 @@ public class NAT : SimplePacketProcessor {
       _DestinationPort = destinationPort;
       // FIXME computing hash at construction relies on address being immutable (addr.Scope can change)
       hashCode = new { SourceAddress, SourcePort, DestinationAddress, DestinationPort }.GetHashCode();
-      #if DEBUG
+#if DEBUG
       asString = this.ToString();
-      #endif
+#endif
     }
 
     public static bool operator ==(MapToOutside_Key a, MapToOutside_Key b)
@@ -371,11 +371,11 @@ public class NAT : SimplePacketProcessor {
     public override int GetHashCode() { return hashCode; }
     public override string ToString()
     {
-      #if DEBUG
+#if DEBUG
       if (asString != null)
         return asString;
       else
-      #endif
+#endif
       return SourceAddress.ToString() + ":" + SourcePort.ToString() + " to "
         + DestinationAddress.ToString() + ":" + DestinationPort.ToString();
     }

--- a/examples/NAT.cs
+++ b/examples/NAT.cs
@@ -144,7 +144,7 @@ public class NAT : SimplePacketProcessor {
   }
 
   /// <summary>
-  /// Rewrite packets coming from the Iside and forward on the Outside network port.
+  /// Rewrite packets coming from the Inside and forward on the Outside network port.
   /// </summary>
   private int inside_to_outside (EthernetPacket p_eth, IpPacket p_ip, TcpPacket p_tcp, int incomingPort)
   {

--- a/examples/NAT.cs
+++ b/examples/NAT.cs
@@ -129,9 +129,9 @@ public class NAT : SimplePacketProcessor {
       // Rewrite destination IP address and TCP port, and map to the appropriate Inside port.
       p_ip.DestinationAddress = destination.Address;
       p_tcp.DestinationPort = destination.Port;
-      // Update checksums. NOTE IP updated before TCP
-      ((IPv4Packet)p_ip).UpdateIPChecksum();
+      // Update checksums.
       p_tcp.UpdateTCPChecksum();
+      ((IPv4Packet)p_ip).UpdateIPChecksum();
       // Update destination MAC address
       p_eth.DestinationHwAddress = destination.MacAddress;
       // Forward on the mapped network interface

--- a/examples/NAT.cs
+++ b/examples/NAT.cs
@@ -134,8 +134,8 @@ public class NAT : SimplePacketProcessor {
       p_tcp.UpdateTCPChecksum();
       // Update destination MAC address
       p_eth.DestinationHwAddress = destination.MacAddress;
-      // Forward on the mapped network port
-      return destination.NetworkPort;
+      // Forward on the mapped network interface
+      return destination.InterfaceNumber;
     }
     else
     {
@@ -193,28 +193,28 @@ public class NAT : SimplePacketProcessor {
   {
     private readonly IPAddress _Address; // FIXME we should really use immutable values since we are using a dictionary
     private readonly ushort _Port;
-    private readonly int _NetworkPort;
+    private readonly int _InterfaceNumber;
     private readonly PhysicalAddress _MacAddress;
     public IPAddress Address { get { return _Address; } }
     public ushort Port { get { return _Port; } }
-    public int NetworkPort { get { return _NetworkPort; } }
+    public int InterfaceNumber { get { return _InterfaceNumber; } }
     public PhysicalAddress MacAddress { get { return _MacAddress; } }
     private readonly int hashCode;
 #if DEBUG
     private string asString;
 #endif
 
-    public InternalNode(IPAddress address, ushort port, int networkPort, PhysicalAddress macAddress)
+    public InternalNode(IPAddress address, ushort port, int interfaceNumber, PhysicalAddress macAddress)
     {
       if (ReferenceEquals(null, address)) throw new ArgumentNullException("address");
       if (ReferenceEquals(null, macAddress)) throw new ArgumentNullException("macAddress");
 
       _Address = address;
       _Port = port;
-      _NetworkPort = networkPort;
+      _InterfaceNumber = interfaceNumber;
       _MacAddress = macAddress;
       // FIXME computing hash at construction relies on address being immutable (addr.Scope can change)
-      hashCode = new { Address, Port, NetworkPort }.GetHashCode();
+      hashCode = new { Address, Port, InterfaceNumber }.GetHashCode();
 #if DEBUG
       asString = this.ToString();
 #endif
@@ -240,7 +240,7 @@ public class NAT : SimplePacketProcessor {
       return !ReferenceEquals(null, other)
         && Address.Equals(other.Address)
         && Port.Equals(other.Port)
-        && NetworkPort.Equals(other.NetworkPort)
+        && InterfaceNumber.Equals(other.InterfaceNumber)
         && MacAddress.Equals(other.MacAddress);
     }
     public override int GetHashCode() { return hashCode; }
@@ -252,7 +252,7 @@ public class NAT : SimplePacketProcessor {
       else
 #endif
       return String.Format("{0}:{1} at {2} on port {3}",
-        Address.ToString(), Port.ToString(), MacAddress.ToString(), NetworkPort.ToString());
+        Address.ToString(), Port.ToString(), MacAddress.ToString(), InterfaceNumber.ToString());
     }
   }
   sealed class MapToInside_Key : IEquatable<MapToInside_Key>

--- a/examples/NAT.cs
+++ b/examples/NAT.cs
@@ -64,14 +64,14 @@ public class NAT : SimplePacketProcessor {
 
   override public int handler (int in_port, ref Packet packet)
   {
-    if (packet is PacketDotNet.EthernetPacket)
+    if (packet is EthernetPacket)
     {
       if (packet.Encapsulates(typeof(IPv4Packet), typeof(TcpPacket)))
       {
         // Unencapsulate the packets, so we can read and change their fields more easily.
         EthernetPacket p_eth = (EthernetPacket)packet;
         IpPacket p_ip = ((IpPacket)(packet.PayloadPacket));
-        TcpPacket p_tcp = ((PacketDotNet.TcpPacket)(p_ip.PayloadPacket));
+        TcpPacket p_tcp = ((TcpPacket)(p_ip.PayloadPacket));
 
 #if DEBUG
         Console.WriteLine("RX {0}:{1} -> {2}:{3} on {4} [{5}]",

--- a/examples/README.md
+++ b/examples/README.md
@@ -107,3 +107,34 @@ through diagnostic messages it emits to the console, and through the packets
 sniffed up by tcpdump on recipient interfaces.
 I use `sudo tcpdump -vvvnXX -i IF` to see a detailed description of each packet,
 replacing `IF` with the interface you want to sniff on.
+
+# Testing the NAT with Mininet
+[Mininet](http://mininet.org/) is a tool for emulating networks on your local machine.
+This is quite handy, because we can run reproducible tests.
+
+To test the NAT implementation:
+- [Install](http://mininet.org/download/) Mininet - VM or otherwise is fine
+- cd into your cloned Pax directory and run `$ sudo ./examples/nat_topo.py test`
+- You can also jump into the Mininet CLI by running `$ sudo ./examples/nat_topo.py`
+
+Feel free to look in `examples/nat_topo.py`:
+- The `NatTopo` class defines the network topology for Mininet 
+```
+                  ┌──────┐     ┌─────┐
+                  |      |-----│ in1 |
+    ┌──────┐      |      |     └─────┘
+    │ out0 |------| nat0 |
+    └──────┘      |      |     ┌─────┐
+                  |      |-----│ in2 |
+                  └──────┘     └─────┘
+```
+- The `createNetwork()` procedure instantiates the network topology and sets up
+  the hosts. It sets the default gateway for the internal hosts to nat0, and
+  disables ip_forwarding on nat0. It also creates firewall rules on each of the
+  interfaces on nat0 to drop all incoming traffic. This is so that only the NAT
+  process will respond to packets. Otherwise, the OS could reject or accept
+  connections that are intended for internal hosts.
+- The `run()` procedure provides a commandline-interface to the network.
+- The `test()` procedure creates a network, tests the NAT implementation by
+  creating a connection between in1 and out0, and then cleans up.
+

--- a/examples/README.md
+++ b/examples/README.md
@@ -149,13 +149,12 @@ Feel free to look in `examples/nat_topo.py`:
                   └──────┘     └─────┘
 ```
 - The `createNetwork()` procedure instantiates the network topology and sets up
-  the hosts. It sets the default gateway for the internal hosts to nat0, and
-  disables ip_forwarding on nat0.
-  
-  It also creates firewall rules on each of the
+  the hosts. It sets the default gateway for the internal hosts to nat0 and
+  creates firewall rules on each of the
   interfaces on nat0 to drop all incoming traffic. This is so that only the NAT
   process will respond to packets. Otherwise, the OS could reject or accept
-  connections that are intended for internal hosts.
+  connections that are intended for internal hosts. (Or unhelpfully forward
+  packets for us)
 
   Take special note that the MAC address of out0 is manually set. This is so because
   the NAT implementation currently requires the next hop to be hardcoded in the config.

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,7 +27,7 @@ The configuration needs to specify three parameters to the NAT's constructor:
 
 * The IP address of the NAT. This will be used as the source address of packets crossing from the Inside to the Outside of the NAT.
 * The starting TCP port to use on the NAT, to proxy TCP connections crossing from the Inside to the Outside of the NAT.
-* The MAC address of the next hop, the node which the Out port (port 0) of the NAT is connected to.
+* The MAC address of the next hop to Outside; the address of the node which the Out port (port 0) of the NAT is connected to.
 
 These parameters are provided as part of the `args` map, as shown in the example NAT configuration below.
 
@@ -149,7 +149,7 @@ it might not be the IP you were expecting.
 
 _
 
-Feel free to look in `examples/nat_topo.py`:
+Feel free to look in [`examples/nat_topo.py`](nat_topo.py):
 - The `NatTopo` class defines the network topology for Mininet 
 ```
                   ┌──────┐     ┌─────┐
@@ -161,7 +161,7 @@ Feel free to look in `examples/nat_topo.py`:
                   └──────┘     └─────┘
 ```
 - You might notice that `nat0` is specified as being a node of type `PaxNode`. You can
-  look at the definition in `pax_mininet_node.py`. It is a host with firewall rules on
+  look at the definition in [`pax_mininet_node.py`](pax_mininet_node.py). It is a host with firewall rules on
   each of the interfaces on nat0 to drop all incoming traffic. This is so that only
   the NAT process will respond to packets. Otherwise, the OS could reject or accept
   connections that are intended for internal hosts. We also disable ip_forward so that

--- a/examples/README.md
+++ b/examples/README.md
@@ -126,7 +126,7 @@ This is quite handy because we can run reproducible tests and experiment with
 networks when we don't have the physical machines otherwise needed.
 
 To test the NAT implementation:
-- [Install](http://mininet.org/download/) Mininet - it doesn't matter which way
+- [Install](http://mininet.org/download/) Mininet - it doesn't matter which way. We used Mininet 2.2.1 on Ubuntu 14.04 LTS.
 - cd into your cloned Pax directory and run `$ sudo ./examples/nat_topo.py test`
 - You can also jump into the Mininet CLI by running `$ sudo ./examples/nat_topo.py`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,32 +23,44 @@ These examples are written in C#, but any [.NET language](https://en.wikipedia.o
 ## NAT example
 
 ### Configuration
-The configuration needs to specify two parameters to the NAT's port 0 (i.e., the port connected to "Outside"):
+The configuration needs to specify three parameters to the NAT's constructor:
 
 * The IP address of the NAT. This will be used as the source address of packets crossing from the Inside to the Outside of the NAT.
 * The starting TCP port to use on the NAT, to proxy TCP connections crossing from the Inside to the Outside of the NAT.
+* The MAC address of the next hop, the node which the Out port (port 0) of the NAT is connected to.
 
-These parameters are provided as part of the `environment` map, as shown in the example NAT configuration below.
+These parameters are provided as part of the `args` map, as shown in the example NAT configuration below.
 
 ```javascript
-[
-  {
-   "interface_name" : "eth0",
-   "lead_handler" : "Nested_NAT",
-   "environment" : {
-      "my_address" : "192.168.3.3",
-      "next_port" : "6000",
-     }
-  },
-  {
-   "interface_name" : "eth1",
-   "lead_handler" : "Nested_NAT",
-  },
-  {
-   "interface_name" : "eth2",
-   "lead_handler" : "Nested_NAT",
-  },
-]
+{
+  "handlers": [
+    {
+      "class_name": "NAT",
+      "args": {
+        "my_address" : "10.0.0.3",
+        "next_port" : "35000",
+        "next_hop_mac" : "00:00:00:00:00:09"
+      }
+    }
+  ],
+  "interfaces": [
+    {
+      "interface_name" : "nat0-eth0",
+      "lead_handler" : "NAT",
+      "pcap_filter" : "tcp"
+    },
+    {
+      "interface_name" : "nat0-eth1",
+      "lead_handler" : "NAT",
+      "pcap_filter" : "tcp"
+    },
+    {
+      "interface_name" : "nat0-eth2",
+      "lead_handler" : "NAT",
+      "pcap_filter" : "tcp"
+    }
+  ]
+}
 ```
 
 ### Testing
@@ -124,7 +136,7 @@ apart from run the automated test. The Mininet
 One very useful thing to know is to use `mininet> host command` in the CLI to run
 `command` on `host`. E.g. to run ifconfig on in1, use `mininet> in1 ifconfig`.
 
-The automated test could be done manually by running these commands:
+We could manually test the NAT by running these commands:
 ``` bash
 $ sudo ./examples/nat_topo.py
 mininet> out0 echo 'Hi from out0!' | netcat -l 12010 &
@@ -132,7 +144,7 @@ mininet> in1 netcat out0 12010
 ```
 Note that on line 3, we specify `out0` instead of the IP of out0. We can do this
 because the Mininet CLI replaces it with the IP. Be aware that this is the IP of the
-default interface, which is fine here because out0 only has one, but on nat0,
+default interface, which is fine here because out0 only has one, but on nat0
 it might not be the IP you were expecting.
 
 _
@@ -148,13 +160,15 @@ Feel free to look in `examples/nat_topo.py`:
                   |      |-----│ in2 |
                   └──────┘     └─────┘
 ```
+- You might notice that `nat0` is specified as being a node of type `PaxNode`. You can
+  look at the definition in `pax_mininet_node.py`. It is a host with firewall rules on
+  each of the interfaces on nat0 to drop all incoming traffic. This is so that only
+  the NAT process will respond to packets. Otherwise, the OS could reject or accept
+  connections that are intended for internal hosts. We also disable ip_forward so that
+  the OS doesn't forward packets that aren't addressed to it.
 - The `createNetwork()` procedure instantiates the network topology and sets up
-  the hosts. It sets the default gateway for the internal hosts to nat0 and
-  creates firewall rules on each of the
-  interfaces on nat0 to drop all incoming traffic. This is so that only the NAT
-  process will respond to packets. Otherwise, the OS could reject or accept
-  connections that are intended for internal hosts. (Or unhelpfully forward
-  packets for us)
+  the hosts. It sets the default gateway for the internal hosts to nat0 so that
+  connections to outside the subnet go through the NAT. 
 
   Take special note that the MAC address of out0 is manually set. This is so because
   the NAT implementation currently requires the next hop to be hardcoded in the config.

--- a/examples/Test.cs
+++ b/examples/Test.cs
@@ -126,10 +126,12 @@ public class Nested_NAT : PacketProcessor {
 
   public Nested_NAT () {
     if (PaxConfig.can_resolve_config_parameter (outside_port, "my_address") &&
-        PaxConfig.can_resolve_config_parameter (outside_port, "next_port"))
+        PaxConfig.can_resolve_config_parameter (outside_port, "next_port") &&
+        PaxConfig.can_resolve_config_parameter (outside_port, "next_hop_mac"))
     {
       pp = new NAT (IPAddress.Parse(PaxConfig.resolve_config_parameter (outside_port, "my_address")),
-          UInt16.Parse(PaxConfig.resolve_config_parameter (outside_port, "next_port")));
+          UInt16.Parse(PaxConfig.resolve_config_parameter (outside_port, "next_port")),
+          PhysicalAddress.Parse(PaxConfig.resolve_config_parameter(outside_port, "next_hop_mac").ToUpper().Replace(':', '-')));
     } else {
       pp = null;
     }

--- a/examples/Test.cs
+++ b/examples/Test.cs
@@ -147,7 +147,7 @@ public class Nested_NAT : PacketProcessor {
 }
 
 /// <summary>
-/// Tallyer prints `|[tag]` everytime a packet is received, where tag is a port-specific configurable string.
+/// Tallyer prints `|[tag]` every time a packet is received, where tag is a port-specific configurable string.
 /// The purpose of Tallyer is to demonstrate and test that default constructors can be used for automatic
 ///  instantiation of PacketProcessors, as well as that port-specific configuration properties can be used.
 /// </summary>
@@ -166,7 +166,7 @@ public class Tallyer : PacketProcessor {
 }
 
 /// <summary>
-/// Dinger just writes `*ding*` everytime a packet is recieved.
+/// Dinger just writes `*ding*` every time a packet is received.
 /// The purpose of Dinger is to demonstrate and test the types that can be used as constructor parameters.
 /// </summary>
 public class Dinger : PacketProcessor {

--- a/examples/nat_topo.py
+++ b/examples/nat_topo.py
@@ -11,6 +11,7 @@ from mininet.net import Mininet
 from mininet.cli import CLI
 from mininet.log import setLogLevel
 import time
+from pax_mininet_node import PaxNode
 
 # This class defines the topology we use for testing the Pax NAT implementation.
 # The parameter `n` defines the number of inside nodes created.
@@ -30,7 +31,7 @@ class NatTopo(Topo):
         Topo.__init__(self, **opts)
 
         # Create the node to host the NAT process:
-        nat = self.addNode("nat0") # FIXME use a PaxNode class? 
+        nat = self.addNode("nat0", cls=PaxNode)
 
         # Create the Outside host:
         # Use a hardcoded MAC address, because we provide the MAC to the NAT as next_hop
@@ -65,14 +66,7 @@ def createNetwork(n=2):
     for i in range(1,n+1):
         h = "in%d" % i
         print "Setting the gateway on %s to %s" % (h, nat0)
-        runCmd(net, h, 'route add 192.168.1.1/32 dev %s-eth0' % h)
-        runCmd(net, h, 'route add default gw 192.168.1.1 dev %s-eth0' % h)
-
-    # Because Pax only sniffs packets (it doesn't steal them), we need to drop the packets
-    #  to prevent the OS from handling them and responding. 
-    print "Drop all incoming TCP traffic on nat0 so that Pax is effectively the middle-man"
-    for i in range(0,n+1):
-        runCmd(net, nat0, "iptables -A INPUT -p tcp -i %s-eth%d -j DROP" % (nat0, i))
+        net.get(h).setDefaultRoute('via 192.168.1.1')
 
     return net
 

--- a/examples/nat_topo.py
+++ b/examples/nat_topo.py
@@ -125,10 +125,12 @@ def test():
 
     # If we couldn't show the Pax output in a separate window, show it now.
     if not config.X_windows:
+        sendInt(net, nat0)
         print "Show Pax output? (Y/n)"
         if (sys.stdin.read(1).upper() == "Y"):
-            sendInt(net, nat0)
-            print waitOutput(net, nat0, verbose=True)
+            waitOutput(net, nat0, verbose=True) # Print output
+        else:
+            waitOutput(net, nat0) # Don't print, just wait
 
 # List topologies defined in this file for Mininet
 topos = { 'nat': (lambda: NatTopo())}

--- a/examples/nat_topo.py
+++ b/examples/nat_topo.py
@@ -100,8 +100,11 @@ def test():
     # Start it in a separate terminal so that we can see the output in real time.
     print "Starting Pax NAT process on %s:" % nat0
     cmd = 'Bin/Pax.exe examples/nat_wiring.json examples/Bin/Examples.dll'
-    if config.X_windows: cmd = 'x-terminal-emulator -e %s &' & cmd
-    sendCmd(net, nat0, cmd)
+    if config.X_windows:
+        cmd = 'x-terminal-emulator -e %s &' % cmd
+        runCmd(net, nat0, cmd)
+    else:
+        sendCmd(net, nat0, cmd)
     
     # Test the NAT by opening a connection between in1 and out0:
     print "Connecting from %s to %s:" % (in1, out0)

--- a/examples/nat_topo.py
+++ b/examples/nat_topo.py
@@ -126,7 +126,7 @@ def test():
     # If we couldn't show the Pax output in a separate window, show it now.
     if not config.X_windows:
         sendInt(net, nat0)
-        print "Show Pax output? (Y/n)"
+        print "Show Pax output? (y/N)"
         if (sys.stdin.read(1).upper() == "Y"):
             waitOutput(net, nat0, verbose=True) # Print output
         else:

--- a/examples/nat_topo.py
+++ b/examples/nat_topo.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+# coding: latin-1
 
 """
 natnet.py: a mininet topology for testing the NAT implementation
@@ -11,80 +12,116 @@ from mininet.cli import CLI
 from mininet.log import setLogLevel
 import time
 
+# This class defines the topology we use for testing the Pax NAT implementation.
+# The parameter `n` defines the number of inside nodes created.
+#                  ┌──────┐     ┌─────┐
+#                  |      |-----│ in1 |
+#    ┌──────┐      |      |     └─────┘
+#    │ out0 |------| nat0 |     ┌─────┐
+#    └──────┘      |      |-----│ in2 |
+#                  |      |     └─────┘
+#                  |      |        ︙    
+#                  |      |     ┌─────┐
+#                  |      |-----│ inN |
+#                  └──────┘     └─────┘
 class NatTopo(Topo):
     "`n` Inside hosts, connected to an Outside host via a node on which NAT can be run"
     def __init__(self, n=2, **opts):
         Topo.__init__(self, **opts)
 
-        # Create the node to host the NAT process
-        nat = self.addNode("nat0")
+        # Create the node to host the NAT process:
+        nat = self.addNode("nat0") # FIXME use a PaxNode class? 
 
-        # Create the Outside host
+        # Create the Outside host:
+        # Use a hardcoded MAC address, because we provide the MAC to the NAT as next_hop
         publicHost = self.addHost("out0", mac="00:00:00:00:00:09")
+        # Link the Outside host (out0) to the NAT on the outside port:
         self.addLink(nat, publicHost, intfName1="nat0-eth0")
 
-        # Create Inside hosts
+        # Create Inside hosts:
         for i in range(1, n+1):
             networkIP = "192.168.1.%d/24" % (i + 9) # Start at 192.168.1.10
             name = "in%d" % i
+            # Create the host with an IP on the inside network
             host = self.addHost(name, ip=networkIP)
+            # Link the host to the NAT, creating an interface on the NAT:
+            # The IP addresses of all the inside ports of NAT are the same because the NAT
+            #  is effectively a NAT router behind a switch, but all in the same node.
             self.addLink(nat, host, intfName1="nat0-eth%d" % i, params1={"ip":"192.168.1.1/24"})
 
-def createNetwork():
-    n = 2
+# Instantiate the NAT network, using NatTopo, and set it up for testing.
+def createNetwork(n=2):
+    # Create the network using NatTopo:
     topo = NatTopo(n=n)
     net = Mininet(topo=topo)
     net.start()
     print "Network started"
     
+    # Names of the hosts we are interested in
     nat0 = "nat0"
     out0 = "out0"
-    in1 = "in1"
-    in2 = "in2"
 
+    # Set the gateway on the inside hosts, so that they use the NAT to send packets outside:
     for i in range(1,n+1):
         h = "in%d" % i
         print "Setting the gateway on %s to %s" % (h, nat0)
         runCmd(net, h, 'route add 192.168.1.1/32 dev %s-eth0' % h)
         runCmd(net, h, 'route add default gw 192.168.1.1 dev %s-eth0' % h)
 
+    # Because Pax only sniffs packets (it doesn't steal them), we need to drop the packets
+    #  to prevent the OS from handling them and responding. 
     print "Drop all incoming TCP traffic on nat0 so that Pax is effectively the middle-man"
     for i in range(0,n+1):
         runCmd(net, nat0, "iptables -A INPUT -p tcp -i %s-eth%d -j DROP" % (nat0, i))
 
     return net
 
-def run():
+# Start the network and open a commandline-interface for manual testing.
+def run(n=2):
     "Create network and run the CLI"
-    net = createNetwork()
+    # Create the network and initialise for testing:
+    net = createNetwork(n)
+    # Start the commandline-interface for interactive testing:
     CLI(net)
+    # Stop and cleanup the network:
     net.stop()
 
+# Start the network, run an automated test, and shut down the network.
 def test():
     "Test the NAT implementation"
-    net = createNetwork()
+    # Create the network and initialise for testing:
+    net = createNetwork(n=2)
 
+    # Names of the hosts we are interested in
     nat0 = "nat0"
     out0 = "out0"
     in1 = "in1"
     in2 = "in2"
     
+    # Start the Pax NAT process on the NAT node:
+    # Start it in a separate terminal so that we can see the output in real time.
     print "Starting Pax NAT process on %s:" % nat0
     runCmd(net, nat0,
         'x-terminal-emulator -e sudo ~/pax/Bin/Pax.exe ~/pax/examples/nat_wiring.json ~/pax/examples/Bin/Examples.dll &')
     
+    # Test the NAT by opening a connection between in1 and out0:
     print "Connecting from %s to %s:" % (in1, out0)
+    # Set up a simple netcat server on out0 to respond with data when in1 connects:
     data = "Hello, are you there?"
     runCmd(net, out0, 'echo %s | netcat -l 12001 &' % data)
+    # Connect to out0 from in1 and get the data received:
     result = runCmd(net, in1, 'netcat -n %s 12001' % ip(net, out0)).rstrip('\n').rstrip('\r')
     received(in1, result)
+    # Check that the received data was correct:
     if (result != data):
         print "WARNING: incorrect data received"
     else:
         print "Correct data received"
 
+# List topologies defined in this file for Mininet
 topos = { 'nat': (lambda: NatTopo())}
 
+# Helper procedures
 def runCmd(net, name, cmd):
     h = net.get(name)
     print "  %s> $ %s" % (name, cmd)
@@ -103,10 +140,13 @@ def ip(net, name):
     return h.IP()
     
 
+# This code runs when the script is executed (e.g. $ sudo ./examples/nat_topo.py)
 import sys
 if __name__ == '__main__':
     setLogLevel('info')
     if len(sys.argv) > 1 and sys.argv[1]=="test":
+        # The command was `$ nat_topo.py test`, so run the automated test:
         test()
     else:
+        # No command argument wsa provided that we understand; start the CLI:
         run()

--- a/examples/nat_topo.py
+++ b/examples/nat_topo.py
@@ -140,7 +140,7 @@ def runCmd(net, name, cmd, timeout=None, **args):
     if (timeout is None):
         return h.cmd(cmd, **args)
     else:
-        timer = threading.Timer(timeout, lambda: h.sendInt())
+        timer = threading.Timer(timeout, lambda: h.sendInt(chr(4)))
         timer.start()
         rv = h.cmd(cmd, **args)
         timer.cancel()

--- a/examples/nat_topo.py
+++ b/examples/nat_topo.py
@@ -96,7 +96,7 @@ def test():
     # Start it in a separate terminal so that we can see the output in real time.
     print "Starting Pax NAT process on %s:" % nat0
     runCmd(net, nat0,
-        'x-terminal-emulator -e sudo ~/pax/Bin/Pax.exe ~/pax/examples/nat_wiring.json ~/pax/examples/Bin/Examples.dll &')
+        'x-terminal-emulator -e sudo Bin/Pax.exe examples/nat_wiring.json examples/Bin/Examples.dll &')
     
     # Test the NAT by opening a connection between in1 and out0:
     print "Connecting from %s to %s:" % (in1, out0)

--- a/examples/nat_topo.py
+++ b/examples/nat_topo.py
@@ -2,7 +2,7 @@
 # coding: latin-1
 
 """
-natnet.py: a mininet topology for testing the NAT implementation
+nat_topo.py: a mininet topology for testing the NAT implementation
 
 """
 

--- a/examples/nat_topo.py
+++ b/examples/nat_topo.py
@@ -1,0 +1,115 @@
+#!/usr/bin/python
+
+"""
+natnet.py: a mininet topology for testing the NAT implementation
+
+"""
+
+from mininet.topo import Topo
+from mininet.net import Mininet
+from mininet.cli import CLI
+from mininet.log import setLogLevel
+import time
+
+class NatTopo(Topo):
+    "`n` Inside hosts, connected to an Outside host via a node on which NAT can be run"
+    def __init__(self, n=2, **opts):
+        Topo.__init__(self, **opts)
+
+        # Create the node to host the NAT process
+        nat = self.addNode("nat0")
+
+        # Create the Outside host
+        publicHost = self.addHost("out0", mac="00:00:00:00:00:09")
+        self.addLink(nat, publicHost, intfName1="nat0-eth0")
+
+        # Create Inside hosts
+        for i in range(1, n+1):
+            networkIP = "192.168.1.%d/24" % (i + 9) # Start at 192.168.1.10
+            name = "in%d" % i
+            host = self.addHost(name, ip=networkIP)
+            self.addLink(nat, host, intfName1="nat0-eth%d" % i, params1={"ip":"192.168.1.1/24"})
+
+def createNetwork():
+    n = 2
+    topo = NatTopo(n=n)
+    net = Mininet(topo=topo)
+    net.start()
+    print "Network started"
+    
+    nat0 = "nat0"
+    out0 = "out0"
+    in1 = "in1"
+    in2 = "in2"
+
+    for i in range(1,n+1):
+        h = "in%d" % i
+        print "Setting the gateway on %s to %s" % (h, nat0)
+        runCmd(net, h, 'route add 192.168.1.1/32 dev %s-eth0' % h)
+        runCmd(net, h, 'route add default gw 192.168.1.1 dev %s-eth0' % h)
+    
+    print "Disabling ip_forwarding on %s" % nat0
+    runCmd(net, nat0, "sysctl -w net.ipv4.ip_forward=0")
+
+    print "Drop all incoming TCP traffic on nat0 so that Pax is effectively the middle-man"
+    for i in range(0,n+1):
+        runCmd(net, nat0, "iptables -A INPUT -p tcp -i %s-eth%d -j DROP" % (nat0, i))
+
+    return net
+
+def run():
+    "Create network and run the CLI"
+    net = createNetwork()
+    CLI(net)
+    net.stop()
+
+def test():
+    "Test the NAT implementation"
+    net = createNetwork()
+
+    nat0 = "nat0"
+    out0 = "out0"
+    in1 = "in1"
+    in2 = "in2"
+    
+    print "Starting Pax NAT process on %s:" % nat0
+    runCmd(net, nat0,
+        'x-terminal-emulator -e sudo ~/pax/Bin/Pax.exe ~/pax/examples/nat_wiring.json ~/pax/examples/Bin/Examples.dll &')
+    
+    print "Connecting from %s to %s:" % (in1, out0)
+    data = "Hello, are you there?"
+    runCmd(net, out0, 'echo %s | netcat -l 12001 &' % data)
+    result = runCmd(net, in1, 'netcat -n %s 12001' % ip(net, out0)).rstrip('\n').rstrip('\r')
+    received(in1, result)
+    if (result != data):
+        print "WARNING: incorrect data received"
+    else:
+        print "Correct data received"
+
+topos = { 'nat': (lambda: NatTopo())}
+
+def runCmd(net, name, cmd):
+    h = net.get(name)
+    print "  %s> $ %s" % (name, cmd)
+    return h.cmd(cmd)
+def sendCmd(net, name, cmd):
+    h = net.get(name)
+    print "  %s> $ %s" % (name, cmd)
+    h.sendCmd(cmd)
+def waitOutput(net, name):
+    h = net.get(name)
+    h.waitOutput()
+def received(name, result):
+    print "  %s> RCV: '%s'" % (name, result)
+def ip(net, name):
+    h = net.get(name)
+    return h.IP()
+    
+
+import sys
+if __name__ == '__main__':
+    setLogLevel('info')
+    if len(sys.argv) > 1 and sys.argv[1]=="test":
+        test()
+    else:
+        run()

--- a/examples/nat_topo.py
+++ b/examples/nat_topo.py
@@ -47,9 +47,6 @@ def createNetwork():
         print "Setting the gateway on %s to %s" % (h, nat0)
         runCmd(net, h, 'route add 192.168.1.1/32 dev %s-eth0' % h)
         runCmd(net, h, 'route add default gw 192.168.1.1 dev %s-eth0' % h)
-    
-    print "Disabling ip_forwarding on %s" % nat0
-    runCmd(net, nat0, "sysctl -w net.ipv4.ip_forward=0")
 
     print "Drop all incoming TCP traffic on nat0 so that Pax is effectively the middle-man"
     for i in range(0,n+1):

--- a/examples/nat_wiring.json
+++ b/examples/nat_wiring.json
@@ -5,7 +5,7 @@
       "args": {
         "my_address" : "10.0.0.3",
         "next_port" : "35000",
-        "next_hop_mac" : "00:00:00:00:00:09"
+        "next_outside_hop_mac" : "00:00:00:00:00:09"
       }
     }
   ],

--- a/examples/nat_wiring.json
+++ b/examples/nat_wiring.json
@@ -4,7 +4,8 @@
       "class_name": "NAT",
       "args": {
         "my_address" : "10.0.0.3",
-        "next_port" : "35000"
+        "next_port" : "35000",
+        "next_hop_mac" : "00:00:00:00:00:09"
       }
     }
   ],

--- a/examples/nat_wiring.json
+++ b/examples/nat_wiring.json
@@ -1,0 +1,31 @@
+{
+  "handlers": [
+    {
+      "class_name": "NAT",
+      "args": {
+        "my_address" : "10.0.0.3",
+        "next_port" : "35000"
+      }
+    }
+  ],
+  "interfaces": [ 
+    { 
+      "interface_name" : "nat0-eth0", 
+      "lead_handler" : "NAT", 
+      "pcap_filter" : "tcp", 
+      "environment" : {
+        "outside_port": "true"
+      } 
+    },
+    { 
+      "interface_name" : "nat0-eth1", 
+      "lead_handler" : "NAT", 
+      "pcap_filter" : "tcp"
+    },
+    { 
+      "interface_name" : "nat0-eth2", 
+      "lead_handler" : "NAT", 
+      "pcap_filter" : "tcp"
+    }
+  ]
+}

--- a/examples/pax_mininet_node.py
+++ b/examples/pax_mininet_node.py
@@ -21,11 +21,14 @@ class PaxNode( Node ):
         #  to prevent the OS from handling them and responding.
         print "Drop all incoming TCP traffic on nat0 so that Pax is effectively the middle-man"
         for intf in self.intfList():
-          self.cmd("iptables -A INPUT -p tcp -i %s -j DROP" % intf.name)
+            self.cmd("iptables -A INPUT -p tcp -i %s -j DROP" % intf.name)
+
+        # Disable ip_forward because otherwise this still happens, even with the above iptables rules
+        self.cmd("sysctl -w net.ipv4.ip_forward=0")
 
     def terminate(self):
         # Remove iptables rules
         for intf in self.intfList():
-          self.cmd("iptables -D INPUT -p tcp -i %s -j DROP" % intf.name)
+            self.cmd("iptables -D INPUT -p tcp -i %s -j DROP" % intf.name)
 
         super(PaxNode, self).terminate()

--- a/examples/pax_mininet_node.py
+++ b/examples/pax_mininet_node.py
@@ -23,9 +23,9 @@ class PaxNode( Node ):
         for intf in self.intfList():
           self.cmd("iptables -A INPUT -p tcp -i %s -j DROP" % intf.name)
 
-    def terminate( self ):
+    def terminate(self):
         # Remove iptables rules
         for intf in self.intfList():
-          runCmd(net, nat0, "iptables -D INPUT -p tcp -i %s -j DROP" % intf.name)
+          self.cmd("iptables -D INPUT -p tcp -i %s -j DROP" % intf.name)
 
-        super( NAT, self ).terminate()
+        super(PaxNode, self).terminate()

--- a/examples/pax_mininet_node.py
+++ b/examples/pax_mininet_node.py
@@ -1,0 +1,31 @@
+# coding: latin-1
+
+"""
+pax_mininet_node.py: Defines PaxNode which allows Pax to behave as the sole packet hander on a node.
+"""
+
+from mininet.node import Node
+from mininet.log import info, warn
+
+class PaxNode( Node ):
+    "PaxNode: A node which allows Pax to behave as the sole packet hander on that node."
+
+    def __init__(self, name, **params):
+        super(PaxNode, self).__init__(name, **params)
+
+    def config(self, **params):
+        super(PaxNode, self).config(**params)
+
+        # Setup iptable rules to drop incoming packets on each interface:
+        # Because Pax only sniffs packets (it doesn't steal them), we need to drop the packets
+        #  to prevent the OS from handling them and responding.
+        print "Drop all incoming TCP traffic on nat0 so that Pax is effectively the middle-man"
+        for intf in self.intfList():
+          self.cmd("iptables -A INPUT -p tcp -i %s -j DROP" % intf.name)
+
+    def terminate( self ):
+        # Remove iptables rules
+        for intf in self.intfList():
+          runCmd(net, nat0, "iptables -D INPUT -p tcp -i %s -j DROP" % intf.name)
+
+        super( NAT, self ).terminate()

--- a/examples/pax_mininet_node.py
+++ b/examples/pax_mininet_node.py
@@ -19,7 +19,6 @@ class PaxNode( Node ):
         # Setup iptable rules to drop incoming packets on each interface:
         # Because Pax only sniffs packets (it doesn't steal them), we need to drop the packets
         #  to prevent the OS from handling them and responding.
-        print "Drop all incoming TCP traffic on nat0 so that Pax is effectively the middle-man"
         for intf in self.intfList():
             self.cmd("iptables -A INPUT -p tcp -i %s -j DROP" % intf.name)
 

--- a/examples/pax_mininet_node.py
+++ b/examples/pax_mininet_node.py
@@ -22,7 +22,9 @@ class PaxNode( Node ):
         for intf in self.intfList():
             self.cmd("iptables -A INPUT -p tcp -i %s -j DROP" % intf.name)
 
-        # Disable ip_forward because otherwise this still happens, even with the above iptables rules
+        # Disable ip_forward because otherwise, even with the above iptables rules, the OS
+        #  will still forward packets that have a different IP on the other interfaces, which
+        #  is not the behaviour we want from an ideal node that only processes packets through Pax.
         self.cmd("sysctl -w net.ipv4.ip_forward=0")
 
     def terminate(self):

--- a/examples/pax_mininet_node.py
+++ b/examples/pax_mininet_node.py
@@ -5,13 +5,13 @@ pax_mininet_node.py: Defines PaxNode which allows Pax to behave as the sole pack
 """
 
 from mininet.node import Node
-from mininet.log import info, warn
 
 class PaxNode( Node ):
     "PaxNode: A node which allows Pax to behave as the sole packet hander on that node."
 
     def __init__(self, name, **params):
         super(PaxNode, self).__init__(name, **params)
+        self.ip_forward = ""
 
     def config(self, **params):
         super(PaxNode, self).config(**params)
@@ -25,11 +25,15 @@ class PaxNode( Node ):
         # Disable ip_forward because otherwise, even with the above iptables rules, the OS
         #  will still forward packets that have a different IP on the other interfaces, which
         #  is not the behaviour we want from an ideal node that only processes packets through Pax.
+        self.ip_forward = self.cmd("sysctl -n net.ipv4.ip_forward")
         self.cmd("sysctl -w net.ipv4.ip_forward=0")
 
     def terminate(self):
         # Remove iptables rules
         for intf in self.intfList():
             self.cmd("iptables -D INPUT -p tcp -i %s -j DROP" % intf.name)
+
+        # Restore ip_forward value
+        self.cmd("sysctl -w net.ipv4.ip_forward=%s" % self.ip_forward)
 
         super(PaxNode, self).terminate()


### PR DESCRIPTION
This PR is dependent on [PR#1](https://github.com/niksu/pax/pull/1).

This PR does the following:
- Improves the NAT implementation so that it works for TCP user applications such as netcat
- Adds tests for the NAT implementation using Mininet, runnable with `$ sudo examples/nat_topo.py test` 
- Adds some basic infrastructure for testing other Pax processes using Mininet. See the `PaxNode` class in `examples/pax_mininet_node.py`.
- Add section on testing with Mininet to the README