### PR TITLE
Improved return types for packet processors

### DIFF
--- a/ForwardingDecision.cs
+++ b/ForwardingDecision.cs
@@ -35,6 +35,7 @@ namespace Pax {
     /// </summary>
     public sealed class Drop : ForwardingDecision {
       // We only need to keep a single instance of Drop, so we use a singleton pattern.
+      private Drop () {}
       public static Drop Instance { get; } = new Drop();
     }
 

--- a/ForwardingDecision.cs
+++ b/ForwardingDecision.cs
@@ -31,7 +31,7 @@ namespace Pax {
 
     // FIXME can use singleton to avoid multiple allocations of this?
     /// <summary>
-    /// The forwarding decision to drop the packet.
+    /// The decision to drop the packet.
     /// </summary>
     public sealed class Drop : ForwardingDecision {
       // We only need to keep a single instance of Drop, so we use a singleton pattern.
@@ -46,7 +46,12 @@ namespace Pax {
     }
 
     /// <summary>
-    /// The forwarding decision to forward the packet to a single port.
+    /// The decision to forward the packet to *at most* a single port.
+    /// Note that a processor that forwards to a single port might still
+    /// decide to drop packets, even if it returns a <c>ForwardingDecision</c>
+    /// of type <c>SinglePortForward</c>. A drop decision within
+    /// <c>SinglePortForward</c> is communicated by having a negative
+    /// "target_port" parameter to the constructor.
     /// </summary>
     public sealed class SinglePortForward : ForwardingDecision {
       public readonly int target_port;
@@ -57,7 +62,11 @@ namespace Pax {
     }
 
     /// <summary>
-    /// The forwarding decision to forward the packet to several ports.
+    /// The decision to forward the packet to any number of ports.
+    /// Note that a processor typed <c>MultiPortForward</c> may still
+    /// decide to drop packets. A drop decision within
+    /// <c>MultiPortForward</c> is communicated by having an empty
+    /// "target_ports" parameter to the constructor.
     /// </summary>
     public sealed class MultiPortForward : ForwardingDecision {
       public readonly int[] target_ports;

--- a/ForwardingDecision.cs
+++ b/ForwardingDecision.cs
@@ -1,0 +1,42 @@
+/*
+Pax : tool support for prototyping packet processors
+Nik Sultana, Cambridge University Computer Lab, June 2016
+
+Use of this source code is governed by the Apache 2.0 license; see LICENSE.
+*/
+
+namespace Pax {
+
+  // A packet processor makes some sort of forwarding decision, in addition
+  // to possibly analysing/modifying the packet (and generating new packets).
+  // The forwarding decision makes clear whether the processor recommends to
+  // * drop the packet (i.e., nothing more is to be done with it)
+  // * forward to a single port
+  // * forward to multiple ports
+  //
+  // NOTE this idiom simulates using algebraic types in C#. It's values are
+  //      analysed using the Visitor pattern.
+  public abstract class ForwardingDecision {
+    private ForwardingDecision() {}
+
+    public sealed class Drop : ForwardingDecision {
+      public Drop () {}
+    }
+
+    public sealed class SinglePortForward : ForwardingDecision {
+      public readonly int target_port;
+
+      public SinglePortForward (int target_port) {
+        this.target_port = target_port;
+      }
+    }
+
+    public sealed class MultiPortForward : ForwardingDecision {
+      public readonly int[] target_ports;
+
+      public MultiPortForward (int[] target_ports) {
+        this.target_ports = target_ports;
+      }
+    }
+  }
+}

--- a/ForwardingDecision.cs
+++ b/ForwardingDecision.cs
@@ -20,6 +20,12 @@ namespace Pax {
   /// NOTE this idiom simulates using algebraic types in C#. It's values are
   ///      analysed using the Visitor pattern.
   /// </remark>
+  /// <remark>
+  /// Note that there is a hierarchy between forwarding decisions: Drop is
+  /// subsumed by SinglePortForward (which allows forwarding to at most one
+  /// port), which is subsumed by MultiPortForward (which allows forwarding to
+  /// any number of ports, including one port, or none).
+  /// </remark>
   public abstract class ForwardingDecision {
     private ForwardingDecision() {}
 

--- a/ForwardingDecision.cs
+++ b/ForwardingDecision.cs
@@ -34,7 +34,15 @@ namespace Pax {
     /// The forwarding decision to drop the packet.
     /// </summary>
     public sealed class Drop : ForwardingDecision {
-      public Drop () {}
+      // We only need to keep a single instance of Drop, so we use a singleton pattern.
+      public static readonly Drop inst;
+      private Drop () {}
+      static Drop () {
+        Drop.inst = new Drop();
+      }
+      public static Drop instance() {
+        return inst;
+      }
     }
 
     /// <summary>

--- a/ForwardingDecision.cs
+++ b/ForwardingDecision.cs
@@ -35,14 +35,7 @@ namespace Pax {
     /// </summary>
     public sealed class Drop : ForwardingDecision {
       // We only need to keep a single instance of Drop, so we use a singleton pattern.
-      public static readonly Drop inst;
-      private Drop () {}
-      static Drop () {
-        Drop.inst = new Drop();
-      }
-      public static Drop instance() {
-        return inst;
-      }
+      public static Drop Instance { get; } = new Drop();
     }
 
     /// <summary>

--- a/ForwardingDecision.cs
+++ b/ForwardingDecision.cs
@@ -19,6 +19,7 @@ namespace Pax {
   public abstract class ForwardingDecision {
     private ForwardingDecision() {}
 
+    // FIXME can use singleton to avoid multiple allocations of this?
     public sealed class Drop : ForwardingDecision {
       public Drop () {}
     }

--- a/ForwardingDecision.cs
+++ b/ForwardingDecision.cs
@@ -7,23 +7,33 @@ Use of this source code is governed by the Apache 2.0 license; see LICENSE.
 
 namespace Pax {
 
-  // A packet processor makes some sort of forwarding decision, in addition
-  // to possibly analysing/modifying the packet (and generating new packets).
-  // The forwarding decision makes clear whether the processor recommends to
-  // * drop the packet (i.e., nothing more is to be done with it)
-  // * forward to a single port
-  // * forward to multiple ports
-  //
-  // NOTE this idiom simulates using algebraic types in C#. It's values are
-  //      analysed using the Visitor pattern.
+  /// <summary>
+  /// A packet processor makes some sort of forwarding decision, in addition
+  /// to possibly analysing/modifying the packet (and generating new packets).
+  /// </summary>
+  /// <remark>
+  /// The forwarding decision makes clear whether the processor recommends to
+  /// * drop the packet (i.e., nothing more is to be done with it)
+  /// * forward to a single port
+  /// * forward to multiple ports
+  ///
+  /// NOTE this idiom simulates using algebraic types in C#. It's values are
+  ///      analysed using the Visitor pattern.
+  /// </remark>
   public abstract class ForwardingDecision {
     private ForwardingDecision() {}
 
     // FIXME can use singleton to avoid multiple allocations of this?
+    /// <summary>
+    /// The forwarding decision to drop the packet.
+    /// </summary>
     public sealed class Drop : ForwardingDecision {
       public Drop () {}
     }
 
+    /// <summary>
+    /// The forwarding decision to forward the packet to a single port.
+    /// </summary>
     public sealed class SinglePortForward : ForwardingDecision {
       public readonly int target_port;
 
@@ -32,6 +42,9 @@ namespace Pax {
       }
     }
 
+    /// <summary>
+    /// The forwarding decision to forward the packet to several ports.
+    /// </summary>
     public sealed class MultiPortForward : ForwardingDecision {
       public readonly int[] target_ports;
 

--- a/Pax.cs
+++ b/Pax.cs
@@ -155,7 +155,7 @@ namespace Pax
         PaxConfig.no_interfaces = PaxConfig.config.Count;
         PaxConfig.deviceMap = new ICaptureDevice[PaxConfig.no_interfaces];
         PaxConfig.interface_lead_handler = new string[PaxConfig.no_interfaces];
-        PaxConfig.interface_lead_handler_obj = new PacketProcessor[PaxConfig.no_interfaces];
+        PaxConfig.interface_lead_handler_obj = new IPacketProcessor[PaxConfig.no_interfaces];
 
         int idx = 0;
         foreach (var i in PaxConfig.config) {
@@ -217,11 +217,11 @@ namespace Pax
 
       // Inspect each type that implements PacketProcessor, trying to instantiate it for use
       foreach (Type type in PaxConfig.assembly.GetExportedTypes()
-                                            .Where(typeof(PacketProcessor).IsAssignableFrom))
+                                            .Where(typeof(IPacketProcessor).IsAssignableFrom))
       {
         // Find which network interfaces this class is handling
         List<int> subscribed = new List<int>();
-        PacketProcessor pp = null;
+        IPacketProcessor pp = null;
         for (int idx = 0; idx < PaxConfig.no_interfaces; idx++)
         {
           // Does this interface have this type specified as the lead handler?
@@ -263,7 +263,7 @@ namespace Pax
       // FIXME add check to see if there's an interface that references a lead_handler that doesn't appear in the assembly. That should be flagged up to the user, and lead to termination of Pax.
     }
 
-    private static PacketProcessor InstantiatePacketProcessor(Type type)
+    private static IPacketProcessor InstantiatePacketProcessor(Type type)
     {
 #if MOREDEBUG
       Console.WriteLine("Trying to instantiate {0}", type);
@@ -286,7 +286,7 @@ namespace Pax
 #endif
 
       // Instantiate the packet processor
-      PacketProcessor pp = PacketProcessorHelper.InstantiatePacketProcessor(type, arguments);
+      IPacketProcessor pp = PacketProcessorHelper.InstantiatePacketProcessor(type, arguments);
       if (pp == null)
         Console.WriteLine("Couldn't instantiate {0}", type.FullName);
       return pp;

--- a/Pax.csproj
+++ b/Pax.csproj
@@ -26,6 +26,7 @@
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="PaxConfig.cs" />
     <Compile Include="ForwardingDecision.cs" />
+    <Compile Include="Paxifax_Aux.cs" />
     <Compile Include="Paxifax.cs" />
     <Compile Include="Pax.cs" />
     <None Include="lib/SharpPcap.dll.config">

--- a/Pax.csproj
+++ b/Pax.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="PaxConfig.cs" />
+    <Compile Include="ForwardingDecision.cs" />
     <Compile Include="Paxifax.cs" />
     <Compile Include="Pax.cs" />
     <None Include="lib/SharpPcap.dll.config">

--- a/PaxConfig.cs
+++ b/PaxConfig.cs
@@ -69,7 +69,7 @@ namespace Pax
     public static Dictionary<string, int> rdeviceMap = new Dictionary<string, int>();
     // Map from device offset to the name of its handler.
     public static string[] interface_lead_handler;
-    public static PacketProcessor[] interface_lead_handler_obj;
+    public static IPacketProcessor[] interface_lead_handler_obj;
 
     // FIXME better to link to function (rather than have indirection) to speed things up at runtime.
     // The file containing the catalogue of network interfaces.

--- a/Paxifax.cs
+++ b/Paxifax.cs
@@ -21,6 +21,7 @@ using System.Threading.Tasks;
 using System.Reflection;
 using System.Linq;
 
+// FIXME use javadoc-style comments to describe the API
 namespace Pax {
 
   // A more abstract interface to packet processors.
@@ -30,130 +31,10 @@ namespace Pax {
     ForwardingDecision process_packet (int in_port, ref Packet packet);
   }
 
-  // FIXME use javadoc-style comments to describe the API
   public interface PacketProcessor : PacketProcessor_Improved {
     void packetHandler (object sender, CaptureEventArgs e);
   }
 
-  internal static class PacketProcessorHelper
-  {
-    public readonly static Type[] AllowedConstructorParameterTypes = new Type[]
-      {
-        typeof(Boolean),  typeof(Byte),   typeof(SByte),  typeof(UInt16),   typeof(Int16),
-        typeof(UInt32),   typeof(Int32),  typeof(UInt64), typeof(Int64),    typeof(Decimal),
-        typeof(Single),   typeof(Double), typeof(String), typeof(DateTime),
-        typeof(TimeSpan), typeof(System.Net.IPAddress), typeof(PhysicalAddress)
-      };
-
-    public static bool IsAllowedConstructorParameterType(Type ty)
-    {
-      // Allow nullable types
-      if (ty.IsGenericType && ty.GetGenericTypeDefinition() == typeof(Nullable<>))
-        ty = Nullable.GetUnderlyingType(ty);
-      return AllowedConstructorParameterTypes.Contains(ty);
-    }
-
-    public static object ConvertConstructorParameter(Type ty, string s)
-    {
-      if (ty == typeof(string))
-        return s;
-      else if (ty == typeof(System.Net.IPAddress))
-        return System.Net.IPAddress.Parse(s);
-      else if (ty == typeof(PhysicalAddress))
-        return PhysicalAddress.Parse(s.ToUpper().Replace(':', '-'));
-      else if (ty == typeof(TimeSpan))
-        return TimeSpan.Parse(s);
-      else
-        // Convert to primitives + DateTime
-        return ((IConvertible)s).ToType(ty, System.Globalization.CultureInfo.CurrentCulture); // NOTE throws InvalidCastException
-    }
-
-    public static string ConstructorString(ConstructorInfo constructor, object[] arguments = null)
-    {
-      IEnumerable<string> parameters;
-      // Get the string representations of the parameters (or arguments if present)
-      if (arguments == null)
-        parameters = constructor.GetParameters()
-                                .Select(p => String.Format("{0}: {1}", p.Name, p.ParameterType.FullName));
-      else
-        parameters = arguments.Select(obj => obj.ToString());
-      // Format nicely so it looks like a constructor
-      return String.Format("{0}({1})", constructor.DeclaringType.Name, String.Join(", ", parameters));
-    }
-
-    public static IEnumerable<Type> GetUsedPaxTypes(Type type)
-    {
-      // Yield implemented Pax interfaces
-      foreach (Type intf in type.GetInterfaces())
-      {
-        if (intf.FullName.StartsWith("Pax."))
-          yield return intf;
-        else
-        {
-          // Check for interfaces lower down
-          foreach (Type subintf in GetUsedPaxTypes(intf))
-            yield return subintf;
-        }
-      }
-
-      // Yield the highest-up extended Pax type
-      type = type.BaseType;
-      while (type != null)
-      {
-        if (type.FullName.StartsWith("Pax."))
-        {
-          yield return type;
-          yield break;
-        }
-        type = type.BaseType;
-      }
-    }
-
-    public static PacketProcessor InstantiatePacketProcessor(Type type, IDictionary<string, string> argsDict)
-    {
-      // Predicate determining if a parameter could be provided
-      Func<ParameterInfo,bool> parameterIsAvailable = param =>
-        argsDict.ContainsKey(param.Name) && IsAllowedConstructorParameterType(param.ParameterType);
-      // Predicate determining if a constructor can be called
-      Func<ConstructorInfo,bool> constructorCanBeCalled = ctor =>
-        ctor.GetParameters().All(parameterIsAvailable);
-
-      // Get the constructors for this type that we could call with the given arguments:
-      var constructors = type.GetConstructors(BindingFlags.Instance | BindingFlags.Public)
-                             .Where(constructorCanBeCalled);
-
-      // Try to instantiate the type, using the best constructor we can:
-      foreach (var constructor in constructors.OrderByDescending(ctor => ctor.GetParameters().Length))
-      {
-        try
-        {
-          // Get the arguments for the constructor, converted to the proper types
-          var arguments =
-            constructor.GetParameters()
-                       .Select(p => ConvertConstructorParameter(p.ParameterType, argsDict[p.Name]))
-                       .ToArray();
-          // Invoke the constructor, instantiating the type
-#if MOREDEBUG
-          Console.WriteLine("Invoking new {0}", ConstructorString(constructor, arguments));
-#endif
-          PacketProcessor pp = (PacketProcessor)constructor.Invoke(arguments);
-          return pp;
-        }
-        catch (Exception ex) when (ex is InvalidCastException
-                                || ex is FormatException)
-        {
-          // If an exception is thrown, ignore it and try the next best constructor
-          // But log it first:
-          Debug.WriteLine("Constructor failed - {0}:", constructor.ToString());
-          Debug.WriteLine(ex);
-        }
-      }
-
-      // If we reach this point, there were no constructors that we could use
-      Console.WriteLine("No suitable constructor could be found.");
-      return null;
-    }
-  }
 
   // A packet monitor does not output anything onto the network, it simply
   // accumulates state based on what it observes happening on the network.
@@ -301,6 +182,127 @@ namespace Pax {
     }
   }
 
+#region Aux functions
+  internal static class PacketProcessorHelper
+  {
+    public readonly static Type[] AllowedConstructorParameterTypes = new Type[]
+      {
+        typeof(Boolean),  typeof(Byte),   typeof(SByte),  typeof(UInt16),   typeof(Int16),
+        typeof(UInt32),   typeof(Int32),  typeof(UInt64), typeof(Int64),    typeof(Decimal),
+        typeof(Single),   typeof(Double), typeof(String), typeof(DateTime),
+        typeof(TimeSpan), typeof(System.Net.IPAddress), typeof(PhysicalAddress)
+      };
+
+    public static bool IsAllowedConstructorParameterType(Type ty)
+    {
+      // Allow nullable types
+      if (ty.IsGenericType && ty.GetGenericTypeDefinition() == typeof(Nullable<>))
+        ty = Nullable.GetUnderlyingType(ty);
+      return AllowedConstructorParameterTypes.Contains(ty);
+    }
+
+    public static object ConvertConstructorParameter(Type ty, string s)
+    {
+      if (ty == typeof(string))
+        return s;
+      else if (ty == typeof(System.Net.IPAddress))
+        return System.Net.IPAddress.Parse(s);
+      else if (ty == typeof(PhysicalAddress))
+        return PhysicalAddress.Parse(s.ToUpper().Replace(':', '-'));
+      else if (ty == typeof(TimeSpan))
+        return TimeSpan.Parse(s);
+      else
+        // Convert to primitives + DateTime
+        return ((IConvertible)s).ToType(ty, System.Globalization.CultureInfo.CurrentCulture); // NOTE throws InvalidCastException
+    }
+
+    public static string ConstructorString(ConstructorInfo constructor, object[] arguments = null)
+    {
+      IEnumerable<string> parameters;
+      // Get the string representations of the parameters (or arguments if present)
+      if (arguments == null)
+        parameters = constructor.GetParameters()
+                                .Select(p => String.Format("{0}: {1}", p.Name, p.ParameterType.FullName));
+      else
+        parameters = arguments.Select(obj => obj.ToString());
+      // Format nicely so it looks like a constructor
+      return String.Format("{0}({1})", constructor.DeclaringType.Name, String.Join(", ", parameters));
+    }
+
+    public static IEnumerable<Type> GetUsedPaxTypes(Type type)
+    {
+      // Yield implemented Pax interfaces
+      foreach (Type intf in type.GetInterfaces())
+      {
+        if (intf.FullName.StartsWith("Pax."))
+          yield return intf;
+        else
+        {
+          // Check for interfaces lower down
+          foreach (Type subintf in GetUsedPaxTypes(intf))
+            yield return subintf;
+        }
+      }
+
+      // Yield the highest-up extended Pax type
+      type = type.BaseType;
+      while (type != null)
+      {
+        if (type.FullName.StartsWith("Pax."))
+        {
+          yield return type;
+          yield break;
+        }
+        type = type.BaseType;
+      }
+    }
+
+    public static PacketProcessor InstantiatePacketProcessor(Type type, IDictionary<string, string> argsDict)
+    {
+      // Predicate determining if a parameter could be provided
+      Func<ParameterInfo,bool> parameterIsAvailable = param =>
+        argsDict.ContainsKey(param.Name) && IsAllowedConstructorParameterType(param.ParameterType);
+      // Predicate determining if a constructor can be called
+      Func<ConstructorInfo,bool> constructorCanBeCalled = ctor =>
+        ctor.GetParameters().All(parameterIsAvailable);
+
+      // Get the constructors for this type that we could call with the given arguments:
+      var constructors = type.GetConstructors(BindingFlags.Instance | BindingFlags.Public)
+                             .Where(constructorCanBeCalled);
+
+      // Try to instantiate the type, using the best constructor we can:
+      foreach (var constructor in constructors.OrderByDescending(ctor => ctor.GetParameters().Length))
+      {
+        try
+        {
+          // Get the arguments for the constructor, converted to the proper types
+          var arguments =
+            constructor.GetParameters()
+                       .Select(p => ConvertConstructorParameter(p.ParameterType, argsDict[p.Name]))
+                       .ToArray();
+          // Invoke the constructor, instantiating the type
+#if MOREDEBUG
+          Console.WriteLine("Invoking new {0}", ConstructorString(constructor, arguments));
+#endif
+          PacketProcessor pp = (PacketProcessor)constructor.Invoke(arguments);
+          return pp;
+        }
+        catch (Exception ex) when (ex is InvalidCastException
+                                || ex is FormatException)
+        {
+          // If an exception is thrown, ignore it and try the next best constructor
+          // But log it first:
+          Debug.WriteLine("Constructor failed - {0}:", constructor.ToString());
+          Debug.WriteLine(ex);
+        }
+      }
+
+      // If we reach this point, there were no constructors that we could use
+      Console.WriteLine("No suitable constructor could be found.");
+      return null;
+    }
+  }
+
   public static class PacketEncap {
     public static bool Encapsulates (this Packet p, params Type[] encs) {
       if (encs.Length > 0)
@@ -322,4 +324,5 @@ namespace Pax {
       }
     }
   }
+#endregion
 }

--- a/Paxifax.cs
+++ b/Paxifax.cs
@@ -7,19 +7,11 @@ Use of this source code is governed by the Apache 2.0 license; see LICENSE.
 */
 
 using System;
-using System.Net.NetworkInformation;
-using System.Collections;
 using System.Collections.Generic;
 using PacketDotNet;
 using SharpPcap;
-using SharpPcap.LibPcap;
-using Newtonsoft.Json;
-using System.IO;
 using System.Text;
 using System.Diagnostics;
-using System.Threading.Tasks;
-using System.Reflection;
-using System.Linq;
 
 // FIXME use javadoc-style comments to describe the API
 namespace Pax {
@@ -199,148 +191,4 @@ namespace Pax {
       return fd;
     }
   }
-
-#region Aux functions
-  internal static class PacketProcessorHelper
-  {
-    public readonly static Type[] AllowedConstructorParameterTypes = new Type[]
-      {
-        typeof(Boolean),  typeof(Byte),   typeof(SByte),  typeof(UInt16),   typeof(Int16),
-        typeof(UInt32),   typeof(Int32),  typeof(UInt64), typeof(Int64),    typeof(Decimal),
-        typeof(Single),   typeof(Double), typeof(String), typeof(DateTime),
-        typeof(TimeSpan), typeof(System.Net.IPAddress), typeof(PhysicalAddress)
-      };
-
-    public static bool IsAllowedConstructorParameterType(Type ty)
-    {
-      // Allow nullable types
-      if (ty.IsGenericType && ty.GetGenericTypeDefinition() == typeof(Nullable<>))
-        ty = Nullable.GetUnderlyingType(ty);
-      return AllowedConstructorParameterTypes.Contains(ty);
-    }
-
-    public static object ConvertConstructorParameter(Type ty, string s)
-    {
-      if (ty == typeof(string))
-        return s;
-      else if (ty == typeof(System.Net.IPAddress))
-        return System.Net.IPAddress.Parse(s);
-      else if (ty == typeof(PhysicalAddress))
-        return PhysicalAddress.Parse(s.ToUpper().Replace(':', '-'));
-      else if (ty == typeof(TimeSpan))
-        return TimeSpan.Parse(s);
-      else
-        // Convert to primitives + DateTime
-        return ((IConvertible)s).ToType(ty, System.Globalization.CultureInfo.CurrentCulture); // NOTE throws InvalidCastException
-    }
-
-    public static string ConstructorString(ConstructorInfo constructor, object[] arguments = null)
-    {
-      IEnumerable<string> parameters;
-      // Get the string representations of the parameters (or arguments if present)
-      if (arguments == null)
-        parameters = constructor.GetParameters()
-                                .Select(p => String.Format("{0}: {1}", p.Name, p.ParameterType.FullName));
-      else
-        parameters = arguments.Select(obj => obj.ToString());
-      // Format nicely so it looks like a constructor
-      return String.Format("{0}({1})", constructor.DeclaringType.Name, String.Join(", ", parameters));
-    }
-
-    public static IEnumerable<Type> GetUsedPaxTypes(Type type)
-    {
-      // Yield implemented Pax interfaces
-      foreach (Type intf in type.GetInterfaces())
-      {
-        if (intf.FullName.StartsWith("Pax."))
-          yield return intf;
-        else
-        {
-          // Check for interfaces lower down
-          foreach (Type subintf in GetUsedPaxTypes(intf))
-            yield return subintf;
-        }
-      }
-
-      // Yield the highest-up extended Pax type
-      type = type.BaseType;
-      while (type != null)
-      {
-        if (type.FullName.StartsWith("Pax."))
-        {
-          yield return type;
-          yield break;
-        }
-        type = type.BaseType;
-      }
-    }
-
-    public static IPacketProcessor InstantiatePacketProcessor(Type type, IDictionary<string, string> argsDict)
-    {
-      // Predicate determining if a parameter could be provided
-      Func<ParameterInfo,bool> parameterIsAvailable = param =>
-        argsDict.ContainsKey(param.Name) && IsAllowedConstructorParameterType(param.ParameterType);
-      // Predicate determining if a constructor can be called
-      Func<ConstructorInfo,bool> constructorCanBeCalled = ctor =>
-        ctor.GetParameters().All(parameterIsAvailable);
-
-      // Get the constructors for this type that we could call with the given arguments:
-      var constructors = type.GetConstructors(BindingFlags.Instance | BindingFlags.Public)
-                             .Where(constructorCanBeCalled);
-
-      // Try to instantiate the type, using the best constructor we can:
-      foreach (var constructor in constructors.OrderByDescending(ctor => ctor.GetParameters().Length))
-      {
-        try
-        {
-          // Get the arguments for the constructor, converted to the proper types
-          var arguments =
-            constructor.GetParameters()
-                       .Select(p => ConvertConstructorParameter(p.ParameterType, argsDict[p.Name]))
-                       .ToArray();
-          // Invoke the constructor, instantiating the type
-#if MOREDEBUG
-          Console.WriteLine("Invoking new {0}", ConstructorString(constructor, arguments));
-#endif
-          IPacketProcessor pp = (IPacketProcessor)constructor.Invoke(arguments);
-          return pp;
-        }
-        catch (Exception ex) when (ex is InvalidCastException
-                                || ex is FormatException)
-        {
-          // If an exception is thrown, ignore it and try the next best constructor
-          // But log it first:
-          Debug.WriteLine("Constructor failed - {0}:", constructor.ToString());
-          Debug.WriteLine(ex);
-        }
-      }
-
-      // If we reach this point, there were no constructors that we could use
-      Console.WriteLine("No suitable constructor could be found.");
-      return null;
-    }
-  }
-
-  public static class PacketEncap {
-    public static bool Encapsulates (this Packet p, params Type[] encs) {
-      if (encs.Length > 0)
-      {
-        if (p.PayloadPacket == null)
-        {
-          // "p" doesn't encapsulate whatever it is that "encs" asks it to,
-          // since "p" doesn't encapsulate anything.
-          return false;
-        } else {
-          if (encs[0].IsAssignableFrom(p.PayloadPacket.GetType())) {
-            return p.PayloadPacket.Encapsulates(encs.Skip(1).ToArray());
-          } else {
-            return false;
-          }
-        }
-      } else {
-        return true;
-      }
-    }
-  }
-#endregion
 }

--- a/Paxifax.cs
+++ b/Paxifax.cs
@@ -141,7 +141,7 @@ namespace Pax {
       {
         out_ports = ((ForwardingDecision.MultiPortForward)des).target_ports;
       } else {
-        throw (new Exception ("Expected SinglePortForward"));
+        throw (new Exception ("Expected MultiPortForward"));
       }
 
 #if DEBUG

--- a/Paxifax_Aux.cs
+++ b/Paxifax_Aux.cs
@@ -1,0 +1,160 @@
+/*
+Pax : tool support for prototyping packet processors
+Nik Sultana, Cambridge University Computer Lab, June 2016
+Jonny Shipton, Cambridge University Computer Lab, July 2016
+
+Use of this source code is governed by the Apache 2.0 license; see LICENSE.
+*/
+
+using System;
+using System.Net.NetworkInformation;
+using System.Collections.Generic;
+using PacketDotNet;
+using System.Reflection;
+using System.Linq;
+using System.Diagnostics;
+
+namespace Pax {
+
+  internal static class PacketProcessorHelper
+  {
+    public readonly static Type[] AllowedConstructorParameterTypes = new Type[]
+      {
+        typeof(Boolean),  typeof(Byte),   typeof(SByte),  typeof(UInt16),   typeof(Int16),
+        typeof(UInt32),   typeof(Int32),  typeof(UInt64), typeof(Int64),    typeof(Decimal),
+        typeof(Single),   typeof(Double), typeof(String), typeof(DateTime),
+        typeof(TimeSpan), typeof(System.Net.IPAddress), typeof(PhysicalAddress)
+      };
+
+    public static bool IsAllowedConstructorParameterType(Type ty)
+    {
+      // Allow nullable types
+      if (ty.IsGenericType && ty.GetGenericTypeDefinition() == typeof(Nullable<>))
+        ty = Nullable.GetUnderlyingType(ty);
+      return AllowedConstructorParameterTypes.Contains(ty);
+    }
+
+    public static object ConvertConstructorParameter(Type ty, string s)
+    {
+      if (ty == typeof(string))
+        return s;
+      else if (ty == typeof(System.Net.IPAddress))
+        return System.Net.IPAddress.Parse(s);
+      else if (ty == typeof(PhysicalAddress))
+        return PhysicalAddress.Parse(s.ToUpper().Replace(':', '-'));
+      else if (ty == typeof(TimeSpan))
+        return TimeSpan.Parse(s);
+      else
+        // Convert to primitives + DateTime
+        return ((IConvertible)s).ToType(ty, System.Globalization.CultureInfo.CurrentCulture); // NOTE throws InvalidCastException
+    }
+
+    public static string ConstructorString(ConstructorInfo constructor, object[] arguments = null)
+    {
+      IEnumerable<string> parameters;
+      // Get the string representations of the parameters (or arguments if present)
+      if (arguments == null)
+        parameters = constructor.GetParameters()
+                                .Select(p => String.Format("{0}: {1}", p.Name, p.ParameterType.FullName));
+      else
+        parameters = arguments.Select(obj => obj.ToString());
+      // Format nicely so it looks like a constructor
+      return String.Format("{0}({1})", constructor.DeclaringType.Name, String.Join(", ", parameters));
+    }
+
+    public static IEnumerable<Type> GetUsedPaxTypes(Type type)
+    {
+      // Yield implemented Pax interfaces
+      foreach (Type intf in type.GetInterfaces())
+      {
+        if (intf.FullName.StartsWith("Pax."))
+          yield return intf;
+        else
+        {
+          // Check for interfaces lower down
+          foreach (Type subintf in GetUsedPaxTypes(intf))
+            yield return subintf;
+        }
+      }
+
+      // Yield the highest-up extended Pax type
+      type = type.BaseType;
+      while (type != null)
+      {
+        if (type.FullName.StartsWith("Pax."))
+        {
+          yield return type;
+          yield break;
+        }
+        type = type.BaseType;
+      }
+    }
+
+    public static IPacketProcessor InstantiatePacketProcessor(Type type, IDictionary<string, string> argsDict)
+    {
+      // Predicate determining if a parameter could be provided
+      Func<ParameterInfo,bool> parameterIsAvailable = param =>
+        argsDict.ContainsKey(param.Name) && IsAllowedConstructorParameterType(param.ParameterType);
+      // Predicate determining if a constructor can be called
+      Func<ConstructorInfo,bool> constructorCanBeCalled = ctor =>
+        ctor.GetParameters().All(parameterIsAvailable);
+
+      // Get the constructors for this type that we could call with the given arguments:
+      var constructors = type.GetConstructors(BindingFlags.Instance | BindingFlags.Public)
+                             .Where(constructorCanBeCalled);
+
+      // Try to instantiate the type, using the best constructor we can:
+      foreach (var constructor in constructors.OrderByDescending(ctor => ctor.GetParameters().Length))
+      {
+        try
+        {
+          // Get the arguments for the constructor, converted to the proper types
+          var arguments =
+            constructor.GetParameters()
+                       .Select(p => ConvertConstructorParameter(p.ParameterType, argsDict[p.Name]))
+                       .ToArray();
+          // Invoke the constructor, instantiating the type
+#if MOREDEBUG
+          Console.WriteLine("Invoking new {0}", ConstructorString(constructor, arguments));
+#endif
+          IPacketProcessor pp = (IPacketProcessor)constructor.Invoke(arguments);
+          return pp;
+        }
+        catch (Exception ex) when (ex is InvalidCastException
+                                || ex is FormatException)
+        {
+          // If an exception is thrown, ignore it and try the next best constructor
+          // But log it first:
+          Debug.WriteLine("Constructor failed - {0}:", constructor.ToString());
+          Debug.WriteLine(ex);
+        }
+      }
+
+      // If we reach this point, there were no constructors that we could use
+      Console.WriteLine("No suitable constructor could be found.");
+      return null;
+    }
+  }
+
+  public static class PacketEncap {
+    public static bool Encapsulates (this Packet p, params Type[] encs) {
+      if (encs.Length > 0)
+      {
+        if (p.PayloadPacket == null)
+        {
+          // "p" doesn't encapsulate whatever it is that "encs" asks it to,
+          // since "p" doesn't encapsulate anything.
+          return false;
+        } else {
+          if (encs[0].IsAssignableFrom(p.PayloadPacket.GetType())) {
+            return p.PayloadPacket.Encapsulates(encs.Skip(1).ToArray());
+          } else {
+            return false;
+          }
+        }
+      } else {
+        return true;
+      }
+    }
+  }
+}

--- a/examples/Hub.cs
+++ b/examples/Hub.cs
@@ -9,8 +9,9 @@ using PacketDotNet;
 using Pax;
 
 public class Hub : MultiInterface_SimplePacketProcessor {
-  override public int[] handler (int in_port, ref Packet packet)
+  override public ForwardingDecision process_packet (int in_port, ref Packet packet)
   {
-    return MultiInterface_SimplePacketProcessor.broadcast(in_port);
+    int[] out_ports = MultiInterface_SimplePacketProcessor.broadcast(in_port);
+    return (new ForwardingDecision.MultiPortForward(out_ports));
   }
 }

--- a/examples/LearningSwitch.cs
+++ b/examples/LearningSwitch.cs
@@ -20,7 +20,7 @@ public class LearningSwitch : MultiInterface_SimplePacketProcessor {
   //    we're in a forwarding loop.
   ConcurrentDictionary<PhysicalAddress,int> forwarding_table = new ConcurrentDictionary<PhysicalAddress,int>();
 
-  override public int[] handler (int in_port, ref Packet packet)
+  override public ForwardingDecision process_packet (int in_port, ref Packet packet)
   {
     int[] out_ports;
 
@@ -78,6 +78,6 @@ public class LearningSwitch : MultiInterface_SimplePacketProcessor {
       out_ports = new int[0];
     }
 
-    return out_ports;
+    return (new ForwardingDecision.MultiPortForward(out_ports));
   }
 }

--- a/examples/Mirror.cs
+++ b/examples/Mirror.cs
@@ -50,7 +50,7 @@ public class Mirror : SimplePacketProcessor {
     {
       // The default configuration is for the mirror to do nothing.
       // This won't get in the way of chained elements transforming or forwarding the packet.
-      cfg[i] = ForwardingDecision.Drop.instance();
+      cfg[i] = ForwardingDecision.Drop.Instance;
     }
 
     return cfg;

--- a/examples/Mirror.cs
+++ b/examples/Mirror.cs
@@ -45,13 +45,12 @@ public class Mirror : SimplePacketProcessor {
   public static ForwardingDecision[] InitialConfig (int size)
   {
     ForwardingDecision[] cfg = new ForwardingDecision[size];
-    ForwardingDecision drop = new ForwardingDecision.Drop();
 
     for (int i = 0; i < cfg.Length; i++)
     {
       // The default configuration is for the mirror to do nothing.
       // This won't get in the way of chained elements transforming or forwarding the packet.
-      cfg[i] = drop;
+      cfg[i] = ForwardingDecision.Drop.instance();
     }
 
     return cfg;

--- a/examples/NAT.cs
+++ b/examples/NAT.cs
@@ -79,7 +79,7 @@ public class NAT : SimplePacketProcessor {
           p_tcp.Syn?"S":"");
 #endif
 
-        ForwardingDecision des = ForwardingDecision.Drop.instance();
+        ForwardingDecision des = ForwardingDecision.Drop.Instance;
         if (in_port == Port_Outside)
           des = outside_to_inside (p_eth, p_ip, p_tcp);
         else
@@ -104,7 +104,7 @@ public class NAT : SimplePacketProcessor {
     }
 
     // Drop packets that aren't handled
-    return ForwardingDecision.Drop.instance();
+    return ForwardingDecision.Drop.Instance;
   }
 
   /// <summary>
@@ -114,7 +114,7 @@ public class NAT : SimplePacketProcessor {
   {
     // p_ip.DestinationAddress should be my_address
     if (!p_ip.DestinationAddress.Equals(my_address))
-      return ForwardingDecision.Drop.instance();
+      return ForwardingDecision.Drop.Instance;
 
     // Retrieve the mapping. If a mapping doesn't exist, then it means that we're not
     // aware of a session to which the packet belongs: so drop the packet.
@@ -135,7 +135,7 @@ public class NAT : SimplePacketProcessor {
     }
     else
     {
-      return ForwardingDecision.Drop.instance();
+      return ForwardingDecision.Drop.Instance;
     }
   }
 
@@ -162,7 +162,7 @@ public class NAT : SimplePacketProcessor {
     else if (!NAT_MapToOutside.TryGetValue(out_key, out masqueradingPort))
     {
       // Not a SYN, and no existing connection, so drop.
-      return ForwardingDecision.Drop.instance();
+      return ForwardingDecision.Drop.Instance;
     }
 
     // Rewrite the packet.

--- a/examples/NAT.cs
+++ b/examples/NAT.cs
@@ -79,7 +79,7 @@ public class NAT : SimplePacketProcessor {
           p_tcp.Syn?"S":"");
 #endif
 
-        ForwardingDecision des = new ForwardingDecision.Drop();
+        ForwardingDecision des = ForwardingDecision.Drop.instance();
         if (in_port == Port_Outside)
           des = outside_to_inside (p_eth, p_ip, p_tcp);
         else
@@ -104,7 +104,7 @@ public class NAT : SimplePacketProcessor {
     }
 
     // Drop packets that aren't handled
-    return (new ForwardingDecision.Drop());
+    return ForwardingDecision.Drop.instance();
   }
 
   /// <summary>
@@ -114,7 +114,7 @@ public class NAT : SimplePacketProcessor {
   {
     // p_ip.DestinationAddress should be my_address
     if (!p_ip.DestinationAddress.Equals(my_address))
-      return (new ForwardingDecision.Drop());
+      return ForwardingDecision.Drop.instance();
 
     // Retrieve the mapping. If a mapping doesn't exist, then it means that we're not
     // aware of a session to which the packet belongs: so drop the packet.
@@ -135,7 +135,7 @@ public class NAT : SimplePacketProcessor {
     }
     else
     {
-      return (new ForwardingDecision.Drop());
+      return ForwardingDecision.Drop.instance();
     }
   }
 
@@ -162,7 +162,7 @@ public class NAT : SimplePacketProcessor {
     else if (!NAT_MapToOutside.TryGetValue(out_key, out masqueradingPort))
     {
       // Not a SYN, and no existing connection, so drop.
-      return (new ForwardingDecision.Drop());
+      return ForwardingDecision.Drop.instance();
     }
 
     // Rewrite the packet.

--- a/examples/NAT.cs
+++ b/examples/NAT.cs
@@ -40,7 +40,6 @@ using Pax;
 using System.Net.NetworkInformation;
 
 public class NAT : SimplePacketProcessor {
-  public const int Port_Drop = -1;
   public const int Port_Outside = 0;
 
   private IPAddress my_address;
@@ -63,7 +62,7 @@ public class NAT : SimplePacketProcessor {
   ConcurrentDictionary<MapToOutside_Key,ushort> NAT_MapToOutside =
     new ConcurrentDictionary<MapToOutside_Key,ushort>();
 
-  override public int handler (int in_port, ref Packet packet)
+  override public ForwardingDecision process_packet (int in_port, ref Packet packet)
   {
     if (packet is EthernetPacket)
     {
@@ -80,11 +79,11 @@ public class NAT : SimplePacketProcessor {
           p_tcp.Syn?"S":"");
 #endif
 
-        int out_port = Port_Drop;
+        ForwardingDecision des = new ForwardingDecision.Drop();
         if (in_port == Port_Outside)
-          out_port = outside_to_inside (p_eth, p_ip, p_tcp);
+          des = outside_to_inside (p_eth, p_ip, p_tcp);
         else
-          out_port = inside_to_outside (p_eth, p_ip, p_tcp, in_port);
+          des = inside_to_outside (p_eth, p_ip, p_tcp, in_port);
 
 #if DEBUG
         Console.WriteLine(" (------ Outside ------)  \t<->\t (------ Inside ------) ");
@@ -100,22 +99,22 @@ public class NAT : SimplePacketProcessor {
         }
 #endif
 
-        return out_port;
+        return des;
       }
     }
 
     // Drop packets that aren't handled
-    return Port_Drop;
+    return (new ForwardingDecision.Drop());
   }
 
   /// <summary>
   /// Rewrite packets coming from the Outside and forward on the relevant Inside network port.
   /// </summary>
-  private int outside_to_inside (EthernetPacket p_eth, IpPacket p_ip, TcpPacket p_tcp)
+  private ForwardingDecision outside_to_inside (EthernetPacket p_eth, IpPacket p_ip, TcpPacket p_tcp)
   {
     // p_ip.DestinationAddress should be my_address
     if (!p_ip.DestinationAddress.Equals(my_address))
-      return Port_Drop;
+      return (new ForwardingDecision.Drop());
 
     // Retrieve the mapping. If a mapping doesn't exist, then it means that we're not
     // aware of a session to which the packet belongs: so drop the packet.
@@ -132,18 +131,18 @@ public class NAT : SimplePacketProcessor {
       // Update destination MAC address
       p_eth.DestinationHwAddress = destination.MacAddress;
       // Forward on the mapped network interface
-      return destination.InterfaceNumber;
+      return (new ForwardingDecision.SinglePortForward(destination.InterfaceNumber));
     }
     else
     {
-      return Port_Drop;
+      return (new ForwardingDecision.Drop());
     }
   }
 
   /// <summary>
   /// Rewrite packets coming from the Inside and forward on the Outside network port.
   /// </summary>
-  private int inside_to_outside (EthernetPacket p_eth, IpPacket p_ip, TcpPacket p_tcp, int incomingPort)
+  private ForwardingDecision inside_to_outside (EthernetPacket p_eth, IpPacket p_ip, TcpPacket p_tcp, int incomingPort)
   {
     var out_key = new MapToOutside_Key(p_ip.SourceAddress, p_tcp.SourcePort,
                                        p_ip.DestinationAddress, p_tcp.DestinationPort);
@@ -163,7 +162,7 @@ public class NAT : SimplePacketProcessor {
     else if (!NAT_MapToOutside.TryGetValue(out_key, out masqueradingPort))
     {
       // Not a SYN, and no existing connection, so drop.
-      return Port_Drop;
+      return (new ForwardingDecision.Drop());
     }
 
     // Rewrite the packet.
@@ -174,7 +173,7 @@ public class NAT : SimplePacketProcessor {
     p_tcp.UpdateTCPChecksum();
     // Update destination MAC address
     p_eth.DestinationHwAddress = next_outside_hop_mac;
-    return Port_Outside;
+    return (new ForwardingDecision.SinglePortForward(Port_Outside));
   }
 
   private ushort GetNewMasqueradingTcpPort()

--- a/examples/Test.cs
+++ b/examples/Test.cs
@@ -66,7 +66,7 @@ public class Test3 : MultiInterface_SimplePacketProcessor {
   }
 }
 
-public class Printer : PacketProcessor {
+public class Printer : IPacketProcessor {
   int id = 0;
 
   // NOTE we always need to have a default constructor, because of how Pax works.
@@ -87,9 +87,9 @@ public class Printer : PacketProcessor {
 }
 
 // Nested packet processor -- it contains a sequence of chained processors.
-public class Nested_Chained_Test : PacketProcessor {
-  PacketProcessor pp =
-    new PacketProcessor_Chain(new List<PacketProcessor>()
+public class Nested_Chained_Test : IPacketProcessor {
+  IPacketProcessor pp =
+    new PacketProcessor_Chain(new List<IPacketProcessor>()
         {
           new Printer(1),
           new Printer(2),
@@ -105,9 +105,9 @@ public class Nested_Chained_Test : PacketProcessor {
   }
 }
 
-public class Nested_Chained_Test2 : PacketProcessor {
+public class Nested_Chained_Test2 : IPacketProcessor {
   ForwardingDecision[] mirror_cfg;
-  PacketProcessor pp;
+  IPacketProcessor pp;
 
   public Nested_Chained_Test2 () {
     mirror_cfg = Mirror.InitialConfig(PaxConfig.no_interfaces);
@@ -115,7 +115,7 @@ public class Nested_Chained_Test2 : PacketProcessor {
     mirror_cfg[0] = new ForwardingDecision.SinglePortForward(2); // Mirror port 0 to port 2
 
     this.pp =
-      new PacketProcessor_Chain(new List<PacketProcessor>()
+      new PacketProcessor_Chain(new List<IPacketProcessor>()
           {
   /* FIXME would be tidier to use this
             new Mirror(
@@ -138,11 +138,11 @@ public class Nested_Chained_Test2 : PacketProcessor {
   }
 }
 
-public class Nested_NAT : PacketProcessor {
+public class Nested_NAT : IPacketProcessor {
   // NOTE we use 0 below since we're interested in the information
   //      related to the outside-facing port, which the NAT designates as being port 0.
   const int outside_port = 0;
-  PacketProcessor pp = null;
+  IPacketProcessor pp = null;
 
   public Nested_NAT () {
     if (PaxConfig.can_resolve_config_parameter (outside_port, "my_address") &&
@@ -176,7 +176,7 @@ public class Nested_NAT : PacketProcessor {
 /// The purpose of Tallyer is to demonstrate and test that default constructors can be used for automatic
 ///  instantiation of PacketProcessors, as well as that port-specific configuration properties can be used.
 /// </summary>
-public class Tallyer : PacketProcessor {
+public class Tallyer : IPacketProcessor {
 
   // implicit default constructor
 
@@ -199,7 +199,7 @@ public class Tallyer : PacketProcessor {
 /// Dinger just writes `*ding*` every time a packet is received.
 /// The purpose of Dinger is to demonstrate and test the types that can be used as constructor parameters.
 /// </summary>
-public class Dinger : PacketProcessor {
+public class Dinger : IPacketProcessor {
 
   // Constructor taking lots of interesting arguments
   public Dinger(

--- a/examples/Test.cs
+++ b/examples/Test.cs
@@ -46,7 +46,7 @@ public class Test2 : SimplePacketProcessor {
   override public ForwardingDecision process_packet (int in_port, ref Packet packet)
   {
     Console.Write("?");
-    return (new ForwardingDecision.Drop());
+    return ForwardingDecision.Drop.instance();
   }
 }
 
@@ -82,7 +82,7 @@ public class Printer : IPacketProcessor {
 
   public ForwardingDecision process_packet (int in_port, ref Packet packet)
   {
-    return (new ForwardingDecision.Drop());
+    return ForwardingDecision.Drop.instance();
   }
 }
 
@@ -191,7 +191,7 @@ public class Tallyer : IPacketProcessor {
 
   public ForwardingDecision process_packet (int in_port, ref Packet packet)
   {
-    return (new ForwardingDecision.Drop());
+    return ForwardingDecision.Drop.instance();
   }
 }
 
@@ -220,6 +220,6 @@ public class Dinger : IPacketProcessor {
 
   public ForwardingDecision process_packet (int in_port, ref Packet packet)
   {
-    return (new ForwardingDecision.Drop());
+    return ForwardingDecision.Drop.instance();
   }
 }

--- a/examples/Test.cs
+++ b/examples/Test.cs
@@ -46,7 +46,7 @@ public class Test2 : SimplePacketProcessor {
   override public ForwardingDecision process_packet (int in_port, ref Packet packet)
   {
     Console.Write("?");
-    return ForwardingDecision.Drop.instance();
+    return ForwardingDecision.Drop.Instance;
   }
 }
 
@@ -82,7 +82,7 @@ public class Printer : IPacketProcessor {
 
   public ForwardingDecision process_packet (int in_port, ref Packet packet)
   {
-    return ForwardingDecision.Drop.instance();
+    return ForwardingDecision.Drop.Instance;
   }
 }
 
@@ -191,7 +191,7 @@ public class Tallyer : IPacketProcessor {
 
   public ForwardingDecision process_packet (int in_port, ref Packet packet)
   {
-    return ForwardingDecision.Drop.instance();
+    return ForwardingDecision.Drop.Instance;
   }
 }
 
@@ -220,6 +220,6 @@ public class Dinger : IPacketProcessor {
 
   public ForwardingDecision process_packet (int in_port, ref Packet packet)
   {
-    return ForwardingDecision.Drop.instance();
+    return ForwardingDecision.Drop.Instance;
   }
 }

--- a/examples/Test.cs
+++ b/examples/Test.cs
@@ -78,6 +78,11 @@ public class Printer : PacketProcessor {
   public void packetHandler (object sender, CaptureEventArgs e) {
     Console.WriteLine(id);
   }
+
+  public ForwardingDecision process_packet (int in_port, ref Packet packet)
+  {
+    return (new ForwardingDecision.Drop());
+  }
 }
 
 // Nested packet processor -- it contains a sequence of chained processors.
@@ -91,6 +96,11 @@ public class Nested_Chained_Test : PacketProcessor {
 
   public void packetHandler (object sender, CaptureEventArgs e) {
     pp.packetHandler (sender, e);
+  }
+
+  public ForwardingDecision process_packet (int in_port, ref Packet packet)
+  {
+    return (pp.process_packet (in_port, ref packet));
   }
 }
 
@@ -120,6 +130,11 @@ public class Nested_Chained_Test2 : PacketProcessor {
   public void packetHandler (object sender, CaptureEventArgs e) {
     pp.packetHandler (sender, e);
   }
+
+  public ForwardingDecision process_packet (int in_port, ref Packet packet)
+  {
+    return (pp.process_packet (in_port, ref packet));
+  }
 }
 
 public class Nested_NAT : PacketProcessor {
@@ -148,6 +163,11 @@ public class Nested_NAT : PacketProcessor {
       throw (new Exception ("The NAT nested in NestedNAT was not initialised."));
     }
   }
+
+  public ForwardingDecision process_packet (int in_port, ref Packet packet)
+  {
+    return (pp.process_packet (in_port, ref packet));
+  }
 }
 
 /// <summary>
@@ -166,6 +186,11 @@ public class Tallyer : PacketProcessor {
       tag = PaxConfig.resolve_config_parameter(port, "tag");
 
     Console.WriteLine("|" + tag);
+  }
+
+  public ForwardingDecision process_packet (int in_port, ref Packet packet)
+  {
+    return (new ForwardingDecision.Drop());
   }
 }
 
@@ -186,9 +211,14 @@ public class Dinger : PacketProcessor {
     if (_string == null) Console.WriteLine("_string == null");
     if (_IPAddress == null) Console.WriteLine("_IPAddress == null");
     if (_PhysicalAddress == null) Console.WriteLine("_PhysicalAddress == null");
-  } 
+  }
 
   public void packetHandler (object sender, CaptureEventArgs e) {
     Console.WriteLine("*ding*");
+  }
+
+  public ForwardingDecision process_packet (int in_port, ref Packet packet)
+  {
+    return (new ForwardingDecision.Drop());
   }
 }


### PR DESCRIPTION
* Instead of returning a `void`, `int`, or `int[]`, we return a `ForwardingDecision`.
* The implementation hitherto has been too reliant on host-based processing. Now the  new `Abstract_PacketProcessor` interface is on equal standing as `Hostbased_PacketProcessor`, and the latter's implementation usually relies on the former. This will allow the specification of packet processors that don't necessarily run on the host.