### PR TITLE
Pax "lite" for targets with limited .NET support

### DIFF
--- a/ForwardingDecision.cs
+++ b/ForwardingDecision.cs
@@ -69,5 +69,27 @@ namespace Pax {
         this.target_ports = target_ports;
       }
     }
+
+    public static int[] broadcast_raw (int in_port)
+    {
+      int[] out_ports = new int[PaxConfig_Lite.no_interfaces - 1];
+      // We retrieve number of interfaces in use from PaxConfig_Lite.
+      // Naturally, we exclude in_port from the interfaces we're forwarding to since this is a broadcast.
+      int idx = 0;
+      for (int ofs = 0; ofs < PaxConfig_Lite.no_interfaces; ofs++)
+      {
+        if (ofs != in_port)
+        {
+          out_ports[idx] = ofs;
+          idx++;
+        }
+      }
+      return out_ports;
+    }
+
+    public static MultiPortForward broadcast (int in_port)
+    {
+      return (new MultiPortForward (broadcast_raw (in_port)));
+    }
   }
 }

--- a/ForwardingDecision.cs
+++ b/ForwardingDecision.cs
@@ -7,6 +7,9 @@ Use of this source code is governed by the Apache 2.0 license; see LICENSE.
 
 namespace Pax {
 
+  // FIXME should there be a Lite version of this class? I think specifically
+  //       it would statically dimension the MultiPortForward's array, and
+  //       perhaps have it write directly to a field in Packet_Buffer.
   /// <summary>
   /// A packet processor makes some sort of forwarding decision, in addition
   /// to possibly analysing/modifying the packet (and generating new packets).

--- a/Pax.cs
+++ b/Pax.cs
@@ -152,14 +152,14 @@ namespace Pax
         JsonSerializer j = new JsonSerializer();
         j.DefaultValueHandling = DefaultValueHandling.Populate;
         PaxConfig.configFile = j.Deserialize<ConfigFile>(r);
-        PaxConfig.no_interfaces = PaxConfig.config.Count;
-        PaxConfig.deviceMap = new ICaptureDevice[PaxConfig.no_interfaces];
-        PaxConfig.interface_lead_handler = new string[PaxConfig.no_interfaces];
-        PaxConfig.interface_lead_handler_obj = new IPacketProcessor[PaxConfig.no_interfaces];
+        PaxConfig_Lite.no_interfaces = PaxConfig.config.Count;
+        PaxConfig.deviceMap = new ICaptureDevice[PaxConfig_Lite.no_interfaces];
+        PaxConfig.interface_lead_handler = new string[PaxConfig_Lite.no_interfaces];
+        PaxConfig.interface_lead_handler_obj = new IPacketProcessor[PaxConfig_Lite.no_interfaces];
 
         int idx = 0;
         foreach (var i in PaxConfig.config) {
-          Debug.Assert (idx < PaxConfig.no_interfaces);
+          Debug.Assert (idx < PaxConfig_Lite.no_interfaces);
 
           PaxConfig.deviceMap[idx] = null;
           //FIXME not using internal_name any more to avoid more lookups. Remove completely?
@@ -222,7 +222,7 @@ namespace Pax
         // Find which network interfaces this class is handling
         List<int> subscribed = new List<int>();
         IPacketProcessor pp = null;
-        for (int idx = 0; idx < PaxConfig.no_interfaces; idx++)
+        for (int idx = 0; idx < PaxConfig_Lite.no_interfaces; idx++)
         {
           // Does this interface have this type specified as the lead handler?
           if ((!String.IsNullOrEmpty(PaxConfig.interface_lead_handler[idx])) &&
@@ -312,7 +312,7 @@ namespace Pax
         });
       // Shutdown on ^C -- FIXME remove handling of ^C or ^D?
       Console.CancelKeyPress += new ConsoleCancelEventHandler(shutdown);
-      for (int idx = 0; idx < PaxConfig.no_interfaces; idx++)
+      for (int idx = 0; idx < PaxConfig_Lite.no_interfaces; idx++)
       {
         if (PaxConfig.interface_lead_handler_obj[idx] == null)
         {

--- a/Pax.csproj
+++ b/Pax.csproj
@@ -21,11 +21,14 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>lib\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="Pax_Lite, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\Bin\Pax_Lite.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="PaxConfig.cs" />
-    <Compile Include="ForwardingDecision.cs" />
     <Compile Include="Paxifax_Aux.cs" />
     <Compile Include="Paxifax.cs" />
     <Compile Include="Pax.cs" />

--- a/Pax.csproj
+++ b/Pax.csproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="PaxConfig.cs" />
+    <Compile Include="ForwardingDecision.cs" />
     <Compile Include="Paxifax_Aux.cs" />
     <Compile Include="Paxifax.cs" />
     <Compile Include="Pax.cs" />

--- a/PaxConfig.cs
+++ b/PaxConfig.cs
@@ -26,7 +26,7 @@ namespace Pax
     public string class_name { get; set; }
     public IDictionary<string,string> args { get; set; }
   }
-  
+
   public class NetworkInterfaceConfig
   {
     // FIXME I no longer use this -- perhaps can erase.
@@ -55,14 +55,6 @@ namespace Pax
 
   // FIXME crude design
   public static class PaxConfig {
-    // This is the number of interfaces in the configuration file.
-    // This must be greater than 1.
-    // Note that no_interfaces may be larger than the number of interfaces to which a packet processor has
-    // been attached (i.e., interfaces that have a "lead_handler" defined in the configuration).
-    // But this is fine, because there might be interface for which we don't want to process
-    // their incoming packets, but we want to be able to forward packets to them nonetheless.
-    public static int no_interfaces;
-
     // Array "maps" from device offset to the device object.
     public static ICaptureDevice[] deviceMap;
     // Map from device name (e.g., "eth1") to device offset.

--- a/PaxConfig.cs
+++ b/PaxConfig.cs
@@ -46,7 +46,7 @@ namespace Pax
     // We use a default timeout of 100ms as a compromise between latency and performance
     //  for flows with very few packets.
     // The default SharpPcap timeout is 1000ms, which can cause problems when very few
-    //  packets are being sent, as they aren't processed in a timely enough manner.  
+    //  packets are being sent, as they aren't processed in a timely enough manner.
     [DefaultValue(100)]
     public int read_timeout { get; set; }
 

--- a/PaxConfig_Lite.cs
+++ b/PaxConfig_Lite.cs
@@ -8,15 +8,24 @@ Use of this source code is governed by the Apache 2.0 license; see LICENSE.
 namespace Pax
 {
   public static class PaxConfig_Lite {
-    // This is the number of interfaces in the configuration file.
+    // This is the number of interfaces that Pax processor instances can
+    // forward to. When running in a full-fledged .NET VM, this indicates the
+    // number of network interfaces in the configuration file. When running
+    // in a constrained environment, this can be set directly by the
+    // system after loading (from some static value, or using a configuration
+    // source that it knows of).
     // This must be greater than 1.
     // Note that no_interfaces may be larger than the number of interfaces to which a packet processor has
     // been attached (i.e., interfaces that have a "lead_handler" defined in the configuration).
     // But this is fine, because there might be interface for which we don't want to process
     // their incoming packets, but we want to be able to forward packets to them nonetheless.
-    public static int no_interfaces;
+    public static int no_interfaces; //FIXME make uint?
 
+//#if LITE
+    // We need static bounds on arrays, and these are
+    // provided by such constants.
     public const uint MAX_PACKET_SIZE = 1500; // Maximum size of a packet in bytes.
     public const uint MAX_INTERFACES = 10; // Maximum number of interfaces we can use.
+//#endif
   }
 }

--- a/PaxConfig_Lite.cs
+++ b/PaxConfig_Lite.cs
@@ -15,5 +15,8 @@ namespace Pax
     // But this is fine, because there might be interface for which we don't want to process
     // their incoming packets, but we want to be able to forward packets to them nonetheless.
     public static int no_interfaces;
+
+    public const uint MAX_PACKET_SIZE = 1500; // Maximum size of a packet in bytes.
+    public const uint MAX_INTERFACES = 10; // Maximum number of interfaces we can use.
   }
 }

--- a/PaxConfig_Lite.cs
+++ b/PaxConfig_Lite.cs
@@ -21,6 +21,13 @@ namespace Pax
     // their incoming packets, but we want to be able to forward packets to them nonetheless.
     public static int no_interfaces; //FIXME make uint?
 
+    // By "phantom forwarding" I mean forwarding to a network port
+    // that doesn't exist (because it's greater than no_interfaces).
+    // Phantom forwarding might occur if we are running a processor that has
+    // been hardcoded to expect a number of network interfaces, but we lack
+    // that number of interfaces in the configuration we're running it in.
+    public static bool ignore_phantom_forwarding = false;
+
 //#if LITE
     // We need static bounds on arrays, and these are
     // provided by such constants.

--- a/PaxConfig_Lite.cs
+++ b/PaxConfig_Lite.cs
@@ -1,0 +1,19 @@
+/*
+Pax : tool support for prototyping packet processors
+Nik Sultana, Cambridge University Computer Lab, June 2016
+
+Use of this source code is governed by the Apache 2.0 license; see LICENSE.
+*/
+
+namespace Pax
+{
+  public static class PaxConfig_Lite {
+    // This is the number of interfaces in the configuration file.
+    // This must be greater than 1.
+    // Note that no_interfaces may be larger than the number of interfaces to which a packet processor has
+    // been attached (i.e., interfaces that have a "lead_handler" defined in the configuration).
+    // But this is fine, because there might be interface for which we don't want to process
+    // their incoming packets, but we want to be able to forward packets to them nonetheless.
+    public static int no_interfaces;
+  }
+}

--- a/Pax_Lite.csproj
+++ b/Pax_Lite.csproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Hand-written .csproj file, based on instructions at https://msdn.microsoft.com/en-us/library/dd576348.aspx-->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <AssemblyName>Pax_Lite</AssemblyName>
+    <OutputPath>Bin\</OutputPath>
+    <OutputType>Library</OutputType>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="PaxConfig_Lite.cs" />
+    <Compile Include="ForwardingDecision.cs" />
+    <Compile Include="Paxifax_Lite.cs" />
+  </ItemGroup>
+<!--
+  <Target Name="Build">
+    <MakeDir Directories="$(OutputPath)" Condition="!Exists('$(OutputPath)')" />
+    <Csc Sources="@(Compile)" OutputAssembly="$(OutputPath)$(AssemblyName).exe" />
+  </Target>
+-->
+</Project>

--- a/Pax_Lite.csproj
+++ b/Pax_Lite.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="PaxConfig_Lite.cs" />
-    <Compile Include="ForwardingDecision.cs" />
     <Compile Include="Paxifax_Lite.cs" />
   </ItemGroup>
 <!--

--- a/Paxifax.cs
+++ b/Paxifax.cs
@@ -16,7 +16,7 @@ using System.Diagnostics;
 // FIXME use javadoc-style comments to describe the API
 namespace Pax {
 
-  // A more abstract interface to packet processors.
+  // An abstract interface to packet processors.
   public interface IAbstract_PacketProcessor {
     ForwardingDecision process_packet (int in_port, ref Packet packet);
   }
@@ -112,23 +112,6 @@ namespace Pax {
   public abstract class MultiInterface_SimplePacketProcessor : IPacketProcessor {
     // Return the offsets of network interfaces that "packet" is to be forwarded to.
     abstract public ForwardingDecision process_packet (int in_port, ref Packet packet);
-
-    public static int[] broadcast (int in_port)
-    {
-      int[] out_ports = new int[PaxConfig.no_interfaces - 1];
-      // We retrieve number of interfaces in use from PaxConfig.
-      // Naturally, we exclude in_port from the interfaces we're forwarding to since this is a broadcast.
-      int idx = 0;
-      for (int ofs = 0; ofs < PaxConfig.no_interfaces; ofs++)
-      {
-        if (ofs != in_port)
-        {
-          out_ports[idx] = ofs;
-          idx++;
-        }
-      }
-      return out_ports;
-    }
 
     public void packetHandler (object sender, CaptureEventArgs e)
     {

--- a/Paxifax.cs
+++ b/Paxifax.cs
@@ -132,15 +132,23 @@ namespace Pax {
 #endif
       for (int idx = 0; idx < out_ports.Length; idx++)
       {
-        PaxConfig.deviceMap[out_ports[idx]].SendPacket(packet);
+        int out_port = out_ports[idx];
+        // Check if trying to send over a non-existent port.
+        if (out_port < PaxConfig_Lite.no_interfaces &&
+            PaxConfig_Lite.ignore_phantom_forwarding) {
+          PaxConfig.deviceMap[out_ports[idx]].SendPacket(packet);
 #if DEBUG
-        if (idx < out_ports.Length - 1)
-        {
-          Debug.Write(PaxConfig.deviceMap[out_ports[idx]].Name + ", ");
-        } else {
-          Debug.Write(PaxConfig.deviceMap[out_ports[idx]].Name);
-        }
+          if (idx < out_ports.Length - 1)
+          {
+             Debug.Write(PaxConfig.deviceMap[out_ports[idx]].Name + ", ");
+          } else {
+             Debug.Write(PaxConfig.deviceMap[out_ports[idx]].Name);
+          }
 #endif
+        } else if (!(out_port < PaxConfig_Lite.no_interfaces) &&
+            !PaxConfig_Lite.ignore_phantom_forwarding) {
+          throw (new Exception ("Tried forward to non-existant port"));
+        }
       }
 
 #if DEBUG

--- a/Paxifax.cs
+++ b/Paxifax.cs
@@ -123,26 +123,41 @@ namespace Pax {
       if (des is ForwardingDecision.MultiPortForward)
       {
         out_ports = ((ForwardingDecision.MultiPortForward)des).target_ports;
+        /*
+        Since MultiPortForward works with arrays, this increases the exposure
+        to dud values:
+        * negative values within arrays
+        * repeated values within arrays
+        * an array might be larger than intended, and contains rubbish data.
+        These could manifest themselves as bugs or abused behaviour.
+        FIXME determine how each of these cases will be treated.
+        */
       } else {
         throw (new Exception ("Expected MultiPortForward"));
       }
 
 #if DEBUG
       Debug.Write(PaxConfig.deviceMap[in_port].Name + " -> ");
+      // It's useful to know the width of the returned array during debugging,
+      // since it might be that the array was wider than intended, and contained
+      // repeated or rubbish values.
+      Debug.Write("[" + out_ports.Length.ToString() + "] ");
 #endif
+
       for (int idx = 0; idx < out_ports.Length; idx++)
       {
         int out_port = out_ports[idx];
         // Check if trying to send over a non-existent port.
-        if (out_port < PaxConfig_Lite.no_interfaces &&
-            PaxConfig_Lite.ignore_phantom_forwarding) {
-          PaxConfig.deviceMap[out_ports[idx]].SendPacket(packet);
+        if (out_port < PaxConfig_Lite.no_interfaces) {
+          PaxConfig.deviceMap[out_port].SendPacket(packet);
 #if DEBUG
+          Debug.Write("(" + out_port.ToString() + ") "); // Show the network interface offset.
+          // And now show the network interface name that the offset resolves to.
           if (idx < out_ports.Length - 1)
           {
-             Debug.Write(PaxConfig.deviceMap[out_ports[idx]].Name + ", ");
+             Debug.Write(PaxConfig.deviceMap[out_port].Name + ", ");
           } else {
-             Debug.Write(PaxConfig.deviceMap[out_ports[idx]].Name);
+             Debug.Write(PaxConfig.deviceMap[out_port].Name);
           }
 #endif
         } else if (!(out_port < PaxConfig_Lite.no_interfaces) &&

--- a/Paxifax_Lite.cs
+++ b/Paxifax_Lite.cs
@@ -5,6 +5,8 @@ Nik Sultana, Cambridge University Computer Lab, June 2016
 Use of this source code is governed by the Apache 2.0 license; see LICENSE.
 */
 
+using return_type = System.Int64; //FIXME can this be used to make the type of "forward" less arbitrary?
+
 // FIXME use javadoc-style comments to describe the API
 namespace Pax {
 
@@ -13,7 +15,7 @@ namespace Pax {
   // the packet processor is executing).
   public static class Packet_Buffer {
     public static byte[] packet = new byte[PaxConfig_Lite.MAX_PACKET_SIZE];
-    public static long forward = 0; // FIXME might not be right place for this
+    public static return_type forward = 0; // FIXME might not be right place for this
   }
 
   // Packet processors.

--- a/Paxifax_Lite.cs
+++ b/Paxifax_Lite.cs
@@ -1,0 +1,16 @@
+/*
+Pax : tool support for prototyping packet processors
+Nik Sultana, Cambridge University Computer Lab, June 2016
+
+Use of this source code is governed by the Apache 2.0 license; see LICENSE.
+*/
+
+// FIXME use javadoc-style comments to describe the API
+namespace Pax {
+
+  // Packet processors.
+  public interface IAbstract_ByteProcessor {
+    ForwardingDecision process_packet (int in_port, ref byte[] packet);
+  }
+
+}

--- a/Paxifax_Lite.cs
+++ b/Paxifax_Lite.cs
@@ -12,5 +12,4 @@ namespace Pax {
   public interface IAbstract_ByteProcessor {
     ForwardingDecision process_packet (int in_port, ref byte[] packet);
   }
-
 }

--- a/Paxifax_Lite.cs
+++ b/Paxifax_Lite.cs
@@ -10,6 +10,6 @@ namespace Pax {
 
   // Packet processors.
   public interface IAbstract_ByteProcessor {
-    ForwardingDecision process_packet (int in_port, ref byte[] packet);
+    void process_packet (int in_port, ref byte[] packet, ref ulong forward);
   }
 }

--- a/Paxifax_Lite.cs
+++ b/Paxifax_Lite.cs
@@ -8,11 +8,17 @@ Use of this source code is governed by the Apache 2.0 license; see LICENSE.
 // FIXME use javadoc-style comments to describe the API
 namespace Pax {
 
-  // Packet processors.
-  public abstract class BytePacket_Processor {
-    byte[] packet = new byte[PaxConfig_Lite.MAX_PACKET_SIZE];
+  // Packet will be retreivable from here, where it will
+  // be deposited by another party (which depends on where
+  // the packet processor is executing).
+  public static class Packet_Buffer {
+    public static byte[] packet = new byte[PaxConfig_Lite.MAX_PACKET_SIZE];
+    public static long forward = 0; // FIXME might not be right place for this
+  }
 
+  // Packet processors.
+  public interface IBytePacket_Processor {
     // FIXME using "long" type is too arbitrary?
-    abstract public long process_packet (byte in_port);
+    void process_packet (byte in_port);
   }
 }

--- a/Paxifax_Lite.cs
+++ b/Paxifax_Lite.cs
@@ -9,9 +9,10 @@ Use of this source code is governed by the Apache 2.0 license; see LICENSE.
 namespace Pax {
 
   // Packet processors.
-  public interface IAbstract_ByteProcessor {
+  public abstract class BytePacket_Processor {
+    byte[] packet = new byte[PaxConfig_Lite.MAX_PACKET_SIZE];
+
     // FIXME using "long" type is too arbitrary?
-    // FIXME should in_port be "uint"?
-    long process_packet (int in_port, ref byte[] packet);
+    abstract public long process_packet (byte in_port);
   }
 }

--- a/Paxifax_Lite.cs
+++ b/Paxifax_Lite.cs
@@ -10,6 +10,8 @@ namespace Pax {
 
   // Packet processors.
   public interface IAbstract_ByteProcessor {
-    void process_packet (int in_port, ref byte[] packet, ref ulong forward);
+    // FIXME using "long" type is too arbitrary?
+    // FIXME should in_port be "uint"?
+    long process_packet (int in_port, ref byte[] packet);
   }
 }

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
 # FIXME: create a .sln file that includes both projects
-xbuild Pax.csproj && xbuild examples/Examples.csproj && echo Success
+xbuild Pax_Lite.csproj && \
+xbuild Pax.csproj && \
+xbuild examples/Examples.csproj && \
+echo Success

--- a/build.sh
+++ b/build.sh
@@ -4,4 +4,5 @@
 xbuild Pax_Lite.csproj && \
 xbuild Pax.csproj && \
 xbuild examples/Examples.csproj && \
+xbuild examples/Hub.csproj && \
 echo Success

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,21 @@
 #!/bin/bash
+# Rudimentary build script
+# Nik Sultana, Cambridge University Computer Lab, July 2016
+#
+# FIXME: replace this with an .sln file
 
-# FIXME: create a .sln file that includes both projects
-xbuild Pax_Lite.csproj /t:Rebuild && \
-xbuild Pax.csproj /t:Rebuild && \
-xbuild examples/Examples.csproj /t:Rebuild && \
-xbuild examples/Hub.csproj /t:Rebuild && \
+set -e
+
+# NOTE to not have any symbols, instead of an empty ${DEFINE} use a dud one like "NOTHING"
+if [ -z "${DEFINE}" ]
+then
+  # Default symbols
+  DEFINE="DEBUG TRACE LITE"
+fi
+
+xbuild Pax_Lite.csproj /t:Rebuild /p:DefineConstants="${DEFINE}"
+xbuild Pax.csproj /p:DefineConstants="${DEFINE}"
+xbuild examples/Examples.csproj /p:DefineConstants="${DEFINE}"
+xbuild examples/Hub.csproj /p:DefineConstants="${DEFINE}"
+
 echo Success

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # FIXME: create a .sln file that includes both projects
-xbuild Pax_Lite.csproj && \
-xbuild Pax.csproj && \
-xbuild examples/Examples.csproj && \
-xbuild examples/Hub.csproj && \
+xbuild Pax_Lite.csproj /t:Rebuild && \
+xbuild Pax.csproj /t:Rebuild && \
+xbuild examples/Examples.csproj /t:Rebuild && \
+xbuild examples/Hub.csproj /t:Rebuild && \
 echo Success

--- a/examples/Examples.csproj
+++ b/examples/Examples.csproj
@@ -23,6 +23,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\lib\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="Pax_Lite, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\Bin\Pax_Lite.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="Pax, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\Bin\Pax.exe</HintPath>
       <SpecificVersion>False</SpecificVersion>

--- a/examples/Hub.cs
+++ b/examples/Hub.cs
@@ -22,9 +22,9 @@ public partial class Hub : MultiInterface_SimplePacketProcessor {
 #endif
 
 public partial class Hub : IAbstract_ByteProcessor {
-  public void process_packet (int in_port, ref byte[] packet, ref ulong forward)
+  public long process_packet (int in_port, ref byte[] packet)
   {
-    forward = 0;
+    long forward = 0;
 
     for (int ofs = 0; ofs < PaxConfig_Lite.no_interfaces; ofs++)
     {
@@ -35,6 +35,6 @@ public partial class Hub : IAbstract_ByteProcessor {
       }
     }
 
-    return;
+    return forward;
   }
 }

--- a/examples/Hub.cs
+++ b/examples/Hub.cs
@@ -9,21 +9,48 @@ using Pax;
 
 #if !LITE
 using PacketDotNet;
-
-public class Hub_PP : MultiInterface_SimplePacketProcessor {
-  override public ForwardingDecision process_packet (int in_port, ref Packet packet)
-  {
-    // Extract the bytes and call the instance of IAbstract_ByteProcessor
-    byte[] bs = packet.Bytes;
-// FIXME    return (process_packet (in_port, ref bs));
-    return (ForwardingDecision.broadcast(in_port));
-    // FIXME simple call Hub.process_packet?
-  }
-}
 #endif
 
-public static class Hub {
-  static public void process_packet (byte in_port)
+
+public
+#if LITE
+static
+#endif
+class Hub
+#if !LITE
+ : MultiInterface_SimplePacketProcessor
+#endif
+ {
+#if !LITE
+  override public ForwardingDecision process_packet (int in_port, ref Packet packet)
+  {
+/* NOTE disabled this since this processor doesn't look at packets, only at the in_port.
+    // Extract the bytes and call the instance of IAbstract_ByteProcessor
+    byte[] bs = packet.Bytes;
+*/
+/* FIXME ideally we should be able use a single implementation of the logic.
+         This is possible, but requires some in-progress development.
+         Specifically this conists of a phase that switches between
+         the high-level and lower-level encoding of in_port, packet, and forward.
+         Then we get two runtime options:
+         * the Pax instance can use the Pax and Pax-Lite level logic (the latter
+           by using the en/decoding)
+         * the Pax_Lite instance can only use the low-level encoding since the
+           types for the high-level encoding are not in its universe.
+
+    process_packet (in_port);
+    TODO var forward = decode_forward();
+    return forward;
+*/
+    return (ForwardingDecision.broadcast(in_port));
+  }
+#endif
+
+  public
+#if LITE
+  static
+#endif
+  void process_packet (byte in_port)
   {
     long forward = Packet_Buffer.forward;
 
@@ -37,5 +64,6 @@ public static class Hub {
     }
 
     Packet_Buffer.forward = forward;
+    //Packet_Buffer.forward = 0xFAFF; // FIXME currently using a constant for debugging
   }
 }

--- a/examples/Hub.cs
+++ b/examples/Hub.cs
@@ -5,13 +5,24 @@ Nik Sultana, Cambridge University Computer Lab, June 2016
 Use of this source code is governed by the Apache 2.0 license; see LICENSE.
 */
 
-using PacketDotNet;
 using Pax;
 
-public class Hub : MultiInterface_SimplePacketProcessor {
+#if !LITE
+using PacketDotNet;
+
+public partial class Hub : MultiInterface_SimplePacketProcessor {
   override public ForwardingDecision process_packet (int in_port, ref Packet packet)
   {
-    int[] out_ports = MultiInterface_SimplePacketProcessor.broadcast(in_port);
-    return (new ForwardingDecision.MultiPortForward(out_ports));
+    // Extract the bytes and call the instance of IAbstract_ByteProcessor
+    byte[] bs = packet.Bytes;
+    return (process_packet (in_port, ref bs));
+  }
+}
+#endif
+
+public partial class Hub : IAbstract_ByteProcessor {
+  public ForwardingDecision process_packet (int in_port, ref byte[] packet)
+  {
+    return (ForwardingDecision.broadcast(in_port));
   }
 }

--- a/examples/Hub.cs
+++ b/examples/Hub.cs
@@ -7,24 +7,25 @@ Use of this source code is governed by the Apache 2.0 license; see LICENSE.
 
 using Pax;
 
-//#if !LITE
-//using PacketDotNet;
-//
-//public partial class Hub : MultiInterface_SimplePacketProcessor {
-//  override public ForwardingDecision process_packet (int in_port, ref Packet packet)
-//  {
-//    // Extract the bytes and call the instance of IAbstract_ByteProcessor
-//    byte[] bs = packet.Bytes;
-//// FIXME    return (process_packet (in_port, ref bs));
-//    return (ForwardingDecision.broadcast(in_port));
-//  }
-//}
-//#endif
+#if !LITE
+using PacketDotNet;
 
-public /*partial*/ class Hub : BytePacket_Processor {
-  override public long process_packet (byte in_port)
+public class Hub_PP : MultiInterface_SimplePacketProcessor {
+  override public ForwardingDecision process_packet (int in_port, ref Packet packet)
   {
-    long forward = 0;
+    // Extract the bytes and call the instance of IAbstract_ByteProcessor
+    byte[] bs = packet.Bytes;
+// FIXME    return (process_packet (in_port, ref bs));
+    return (ForwardingDecision.broadcast(in_port));
+    // FIXME simple call Hub.process_packet?
+  }
+}
+#endif
+
+public static class Hub {
+  static public void process_packet (byte in_port)
+  {
+    long forward = Packet_Buffer.forward;
 
     for (int ofs = 0; ofs < PaxConfig_Lite.no_interfaces; ofs++)
     {
@@ -35,6 +36,6 @@ public /*partial*/ class Hub : BytePacket_Processor {
       }
     }
 
-    return forward;
+    Packet_Buffer.forward = forward;
   }
 }

--- a/examples/Hub.cs
+++ b/examples/Hub.cs
@@ -7,22 +7,22 @@ Use of this source code is governed by the Apache 2.0 license; see LICENSE.
 
 using Pax;
 
-#if !LITE
-using PacketDotNet;
+//#if !LITE
+//using PacketDotNet;
+//
+//public partial class Hub : MultiInterface_SimplePacketProcessor {
+//  override public ForwardingDecision process_packet (int in_port, ref Packet packet)
+//  {
+//    // Extract the bytes and call the instance of IAbstract_ByteProcessor
+//    byte[] bs = packet.Bytes;
+//// FIXME    return (process_packet (in_port, ref bs));
+//    return (ForwardingDecision.broadcast(in_port));
+//  }
+//}
+//#endif
 
-public partial class Hub : MultiInterface_SimplePacketProcessor {
-  override public ForwardingDecision process_packet (int in_port, ref Packet packet)
-  {
-    // Extract the bytes and call the instance of IAbstract_ByteProcessor
-    byte[] bs = packet.Bytes;
-// FIXME    return (process_packet (in_port, ref bs));
-    return (ForwardingDecision.broadcast(in_port));
-  }
-}
-#endif
-
-public partial class Hub : IAbstract_ByteProcessor {
-  public long process_packet (int in_port, ref byte[] packet)
+public /*partial*/ class Hub : BytePacket_Processor {
+  override public long process_packet (byte in_port)
   {
     long forward = 0;
 

--- a/examples/Hub.cs
+++ b/examples/Hub.cs
@@ -15,14 +15,26 @@ public partial class Hub : MultiInterface_SimplePacketProcessor {
   {
     // Extract the bytes and call the instance of IAbstract_ByteProcessor
     byte[] bs = packet.Bytes;
-    return (process_packet (in_port, ref bs));
+// FIXME    return (process_packet (in_port, ref bs));
+    return (ForwardingDecision.broadcast(in_port));
   }
 }
 #endif
 
 public partial class Hub : IAbstract_ByteProcessor {
-  public ForwardingDecision process_packet (int in_port, ref byte[] packet)
+  public void process_packet (int in_port, ref byte[] packet, ref ulong forward)
   {
-    return (ForwardingDecision.broadcast(in_port));
+    forward = 0;
+
+    for (int ofs = 0; ofs < PaxConfig_Lite.no_interfaces; ofs++)
+    {
+      forward = forward << 1;
+      if (ofs != in_port)
+      {
+        forward |= 1;
+      }
+    }
+
+    return;
   }
 }

--- a/examples/Hub.csproj
+++ b/examples/Hub.csproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Hand-written .csproj file, based on instructions at https://msdn.microsoft.com/en-us/library/dd576348.aspx-->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <AssemblyName>Hub</AssemblyName>
+    <OutputPath>Bin\</OutputPath>
+    <OutputType>Library</OutputType>
+    <DefineConstants>DEBUG;TRACE;LITE</DefineConstants>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <Reference Include="Pax_Lite, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\Bin\Pax_Lite.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Hub.cs" />
+  </ItemGroup>
+<!--
+  <Target Name="Build">
+    <MakeDir Directories="$(OutputPath)" Condition="!Exists('$(OutputPath)')" />
+    <Csc Sources="@(Compile)" OutputAssembly="$(OutputPath)$(AssemblyName).exe" />
+  </Target>
+-->
+</Project>

--- a/examples/Hub.csproj
+++ b/examples/Hub.csproj
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Hand-written .csproj file, based on instructions at https://msdn.microsoft.com/en-us/library/dd576348.aspx-->
+<!--
+ Hand-written .csproj file, based on instructions at https://msdn.microsoft.com/en-us/library/dd576348.aspx
+ Got further advice from http://stackoverflow.com/questions/2016697/msbuild-exe-not-accepting-either-pdefineconstants-nor-ppreprocessordefinitio
+-->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <AssemblyName>Hub</AssemblyName>
     <OutputPath>Bin\</OutputPath>
     <OutputType>Library</OutputType>
-    <DefineConstants>DEBUG;TRACE;LITE</DefineConstants>
+    <!--DefineConstants>DEBUG;TRACE;LITE</DefineConstants-->
+    <DefineConstants Condition=" '$(DefineConstants)'==''" >DEBUG;TRACE;LITE</DefineConstants>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
@@ -20,6 +24,7 @@
   </ItemGroup>
 <!--
   <Target Name="Build">
+    <MSBuild Projects="@(Projects)" Properties="DefineConstants=$(DefineConstants)"/>
     <MakeDir Directories="$(OutputPath)" Condition="!Exists('$(OutputPath)')" />
     <Csc Sources="@(Compile)" OutputAssembly="$(OutputPath)$(AssemblyName).exe" />
   </Target>

--- a/examples/LearningSwitch.cs
+++ b/examples/LearningSwitch.cs
@@ -43,7 +43,7 @@ public class LearningSwitch : MultiInterface_SimplePacketProcessor {
           out_ports = new int[1]{lookup_out_port};
         }
       } else {
-        out_ports = MultiInterface_SimplePacketProcessor.broadcast(in_port);
+        out_ports = ForwardingDecision.broadcast_raw(in_port);
       }
 
       // This might hold the value that's mapped to by eth.SourceHwAddress,

--- a/examples/Mirror.cs
+++ b/examples/Mirror.cs
@@ -28,7 +28,7 @@ public class Mirror : SimplePacketProcessor {
 
   public Mirror (ForwardingDecision[] mirror) {
     instantiated = true;
-    Debug.Assert(mirror.Length == PaxConfig.no_interfaces);
+    Debug.Assert(mirror.Length == PaxConfig_Lite.no_interfaces);
     this.mirror = mirror;
   }
 

--- a/examples/Test.cs
+++ b/examples/Test.cs
@@ -36,7 +36,7 @@ public class Test1 : SimplePacketProcessor {
 
   override public ForwardingDecision process_packet (int in_port, ref Packet packet)
   {
-    Console.Write("{0}({1}/{2}) ", in_port, Interlocked.Increment(ref count), PaxConfig.no_interfaces);
+    Console.Write("{0}({1}/{2}) ", in_port, Interlocked.Increment(ref count), PaxConfig_Lite.no_interfaces);
     return (new ForwardingDecision.SinglePortForward(1)); // This behaves like a static switch: it forwards everything to port 1.
   }
 }
@@ -59,9 +59,9 @@ public class Test3 : MultiInterface_SimplePacketProcessor {
   {
 #if DEBUG
     Console.Write("!");
-    Console.Write("{0}({1}/{2}) ", in_port, Interlocked.Increment(ref count), PaxConfig.no_interfaces);
+    Console.Write("{0}({1}/{2}) ", in_port, Interlocked.Increment(ref count), PaxConfig_Lite.no_interfaces);
 #endif
-    int[] target_ports = MultiInterface_SimplePacketProcessor.broadcast(in_port);
+    int[] target_ports = ForwardingDecision.broadcast_raw(in_port);
     return (new ForwardingDecision.MultiPortForward(target_ports));
   }
 }
@@ -110,8 +110,8 @@ public class Nested_Chained_Test2 : IPacketProcessor {
   IPacketProcessor pp;
 
   public Nested_Chained_Test2 () {
-    mirror_cfg = Mirror.InitialConfig(PaxConfig.no_interfaces);
-    Debug.Assert(PaxConfig.no_interfaces >= 3);
+    mirror_cfg = Mirror.InitialConfig(PaxConfig_Lite.no_interfaces);
+    Debug.Assert(PaxConfig_Lite.no_interfaces >= 3);
     mirror_cfg[0] = new ForwardingDecision.SinglePortForward(2); // Mirror port 0 to port 2
 
     this.pp =
@@ -119,7 +119,7 @@ public class Nested_Chained_Test2 : IPacketProcessor {
           {
   /* FIXME would be tidier to use this
             new Mirror(
-              Mirror.InitialConfig(PaxConfig.no_interfaces).MirrorPort(0, 2)
+              Mirror.InitialConfig(PaxConfig_Lite.no_interfaces).MirrorPort(0, 2)
               ),
   */
             new Mirror(mirror_cfg),

--- a/examples/hub_wiring.json
+++ b/examples/hub_wiring.json
@@ -1,0 +1,12 @@
+{
+  "interfaces": [
+    {
+      "interface_name" : "en0",
+      "lead_handler" : "Hub"
+    },
+    {
+      "interface_name" : "en3",
+      "lead_handler" : "Hub"
+    }
+  ]
+}


### PR DESCRIPTION
The goal of this patch is twofold:
* to expose a minimal API for packet processors that doesn't depend on a wide variety of .NET features (or libraries, which might make use of those features). This also includes making limited use of the .NET standard (class) library.
* make use of only simple functions, involving memory allocations that can be dimensioned statically.

This will make it possible to run Pax packet processors on systems that don't (yet) support a very broad subset of .NET's features (as visible in the CIL).

The Hub example is being used as a test case.

Originally I had wanted to include the ForwardingDecision class in Pax_Lite, but unfortunately the array in MultiPortForward cannot be dimensioned statically. Perhaps ForwardingDecision could be refactored to avoid this problem.

Despite being "lite", this interface shouldn't force programmers to use low-level expression to describe packet processors.