### PR TITLE
added default handler for interfaces that haven't been assigned a packet handler

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -1,0 +1,3 @@
+# Command-line interface
+* `-v`: produce more verbose output.
+* `-no-default`: by default Pax uses the "Dropper" element when the handler named in a .json file cannot be found, as well as emits a message. Using this flag results in a default not being substituted (but a message is still emitted), as a consequence of which Pax might crash complaining that the handler couldn't be found.

--- a/CLI.md
+++ b/CLI.md
@@ -1,3 +1,3 @@
 # Command-line interface
 * `-v`: produce more verbose output.
-* `-no-default`: by default Pax uses the "Dropper" element when the handler named in a .json file cannot be found, as well as emits a message. Using this flag results in a default not being substituted (but a message is still emitted), as a consequence of which Pax might crash complaining that the handler couldn't be found.
+* `-no-default`: by default Pax uses the "Dropper" element when the handler named in a .json file cannot be found, as well as emits a message. Using this flag results in a default not being substituted (but a message is still emitted), as a consequence of which Pax might crash complaining that the handler couldn't be found. For more see [examples/nonsense_wiring.json](examples/nonsense_wiring.json).

--- a/Pax.cs
+++ b/Pax.cs
@@ -68,7 +68,8 @@ namespace Pax
 #endif
 
       OptionSet p = new OptionSet ()
-        .Add ("v", _ => PaxConfig.opt_verbose = true);
+        .Add ("v", _ => PaxConfig.opt_verbose = true)
+        .Add ("nodefault", _ => PaxConfig.opt_nodefault = true);
       args = p.Parse(args).ToArray();
 
       if (args.Length < 2)
@@ -338,8 +339,11 @@ namespace Pax
           Console.ForegroundColor = ConsoleColor.Gray;
           Console.WriteLine(")");
           Console.ForegroundColor = tmp;
+
           // If we don't have a packet processor for an interface, we assign the Dropper.
-          PaxConfig.deviceMap[idx].OnPacketArrival += (new Dropper()).packetHandler;
+          if (!PaxConfig.opt_nodefault) {
+            PaxConfig.deviceMap[idx].OnPacketArrival += (new Dropper()).packetHandler;
+          }
         } else {
           var tmp = Console.ForegroundColor;
           Console.ForegroundColor = ConsoleColor.Gray;

--- a/Pax.cs
+++ b/Pax.cs
@@ -338,6 +338,8 @@ namespace Pax
           Console.ForegroundColor = ConsoleColor.Gray;
           Console.WriteLine(")");
           Console.ForegroundColor = tmp;
+          // If we don't have a packet processor for an interface, we assign the Dropper.
+          PaxConfig.deviceMap[idx].OnPacketArrival += (new Dropper()).packetHandler;
         } else {
           var tmp = Console.ForegroundColor;
           Console.ForegroundColor = ConsoleColor.Gray;

--- a/Pax.cs
+++ b/Pax.cs
@@ -69,7 +69,7 @@ namespace Pax
 
       OptionSet p = new OptionSet ()
         .Add ("v", _ => PaxConfig.opt_verbose = true)
-        .Add ("nodefault", _ => PaxConfig.opt_nodefault = true);
+        .Add ("no-default", _ => PaxConfig.opt_no_default = true);
       args = p.Parse(args).ToArray();
 
       if (args.Length < 2)
@@ -341,7 +341,7 @@ namespace Pax
           Console.ForegroundColor = tmp;
 
           // If we don't have a packet processor for an interface, we assign the Dropper.
-          if (!PaxConfig.opt_nodefault) {
+          if (!PaxConfig.opt_no_default) {
             PaxConfig.deviceMap[idx].OnPacketArrival += (new Dropper()).packetHandler;
           }
         } else {

--- a/PaxConfig.cs
+++ b/PaxConfig.cs
@@ -74,6 +74,7 @@ namespace Pax
     public static List<NetworkInterfaceConfig> config { get { return configFile.interfaces; } }
 
     public static bool opt_verbose = false;
+    public static bool opt_nodefault = false;
 
     public static string resolve_config_parameter (int port_no, string key) {
       NetworkInterfaceConfig port_conf;

--- a/PaxConfig.cs
+++ b/PaxConfig.cs
@@ -74,7 +74,7 @@ namespace Pax
     public static List<NetworkInterfaceConfig> config { get { return configFile.interfaces; } }
 
     public static bool opt_verbose = false;
-    public static bool opt_nodefault = false;
+    public static bool opt_no_default = false;
 
     public static string resolve_config_parameter (int port_no, string key) {
       NetworkInterfaceConfig port_conf;

--- a/Paxifax.cs
+++ b/Paxifax.cs
@@ -205,4 +205,11 @@ namespace Pax {
     void Start ();
     void Stop ();
   }
+
+  public class Dropper : PacketMonitor {
+    override public ForwardingDecision process_packet (int in_port, ref Packet packet)
+    {
+      return ForwardingDecision.Drop.Instance;
+    }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The drawing example shows an assembly with four packet processors, only two of w
 
 # Running
 Simply run `Pax.exe CONFIGURATION_FILENAME ASSEMBLY_FILENAME`.
+For more on command-line switches, see [CLI.md](CLI.md).
 Probably you'd have to run this command with root/administrator-level access
 because of the privileged access to hardware that's used while Pax is running.
 For the example code I run:

--- a/examples/nonsense_wiring.json
+++ b/examples/nonsense_wiring.json
@@ -1,0 +1,9 @@
+{
+  "interfaces": [
+    {
+      "interface_name" : "lo0",
+      "lead_handler" : "SomeNameOfAHandlerThatDoesntExist10101010!"
+    }
+  ],
+  "reason": "This is used to test the -no-default command-line switch. I'd expect that '$ sudo mono ./Bin/Pax.exe examples/nonsense_wiring.json examples/Bin/Examples.dll' behaves fine but '$ sudo mono ./Bin/Pax.exe -no-default examples/nonsense_wiring.json examples/Bin/Examples.dll' will crash rather quickly with an unhandled exception related to 'SharpPcap.DeviceNotReadyException: No delegates assigned to OnPacketArrival, no where for captured packets to go.'."
+}


### PR DESCRIPTION
The default handler simply drops the packets (wrt this instance of Pax -- there might be other packet handlers run by other instances of Pax, or servers running on the host;