### PR TITLE
added public shutdown function for Frontend

### DIFF
--- a/Pax.cs
+++ b/Pax.cs
@@ -392,5 +392,9 @@ namespace Pax
       Console.ResetColor();
       Console.WriteLine ("Terminating");
     }
+
+    public static void shutdown () {
+      shutdown(null, null);
+    }
   }
 }


### PR DESCRIPTION
Pax elements can now cleanly terminate Pax using this function. This is mainly useful for batch-style elements, but could also be used by other elements to shut Pax down in case of irrecoverable errors, say.