### PR TITLE
Fix mn scripts to work on my system

### DIFF
--- a/examples/EthernetEcho/ethernet_echo.json
+++ b/examples/EthernetEcho/ethernet_echo.json
@@ -10,7 +10,7 @@
   ],
   "interfaces": [
     {
-      "interface_name" : "eth0",
+      "interface_name" : "echoer-eth0",
       "lead_handler" : "EthernetEcho",
       "pcap_filter" : ""
     }

--- a/examples/EthernetEcho/mn_ethernet_echo.py
+++ b/examples/EthernetEcho/mn_ethernet_echo.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# coding: latin-1
+
 # Mininet testing script for EthernetEcho
 # Nik Sultana, February 2017
 #

--- a/examples/EthernetEcho/mn_ethernet_echo.py
+++ b/examples/EthernetEcho/mn_ethernet_echo.py
@@ -38,7 +38,7 @@ echoer.cmd("sysctl -w net.ipv4.ip_forward=0")
 
 echoer.cmd("sudo " + PAX + "/Bin/Pax.exe " + PAX + "/examples/EthernetEcho/ethernet_echo.json " + PAX + "/examples/Bin/Examples.dll &")
 
-output = host.cmdPrint("sudo python " + PAX + "/ee_test.py")
+output = host.cmdPrint("sudo python " + PAX + "/examples/EthernetEcho/mn_ethernet_echo_test.py")
 print output
 
 net.stop()

--- a/examples/EthernetEcho/mn_ethernet_echo_test.py
+++ b/examples/EthernetEcho/mn_ethernet_echo_test.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# coding: latin-1
+
 # Scapy testing script for EthernetEcho
 # Nik Sultana, February 2017
 #


### PR DESCRIPTION
There were a few changes that had to be made in order to get the scripts to run on my system. (Aside from making sure I had all the dependencies!)

- Add  shebang
- Change ee_test.py to mn_ethernet_echo_test.py
- Change eth0 to echoer-eth0 in the config json

Whilst I was debugging this I also set it up to print the Pax output, but I don't think that is normally appropriate.