### PR TITLE
fixed misleading behaviour

### DIFF
--- a/Pax.cs
+++ b/Pax.cs
@@ -68,8 +68,7 @@ namespace Pax
 #endif
 
       OptionSet p = new OptionSet ()
-        .Add ("v", _ => PaxConfig.opt_verbose = true)
-        .Add ("no-default", _ => PaxConfig.opt_no_default = true);
+        .Add ("v", _ => PaxConfig.opt_verbose = true);
       args = p.Parse(args).ToArray();
 
       if (args.Length < 2)
@@ -340,10 +339,10 @@ namespace Pax
           Console.WriteLine(")");
           Console.ForegroundColor = tmp;
 
-          // If we don't have a packet processor for an interface, we assign the Dropper.
-          if (!PaxConfig.opt_no_default) {
-            PaxConfig.deviceMap[idx].OnPacketArrival += (new Dropper()).packetHandler;
-          }
+          // FIXME create a custom exception subtype for this situation.
+          throw new Exception("Could not instantiate '" +
+              PaxConfig.config[idx].lead_handler +
+              "' -- perhaps not a packet processor?");
         } else {
           var tmp = Console.ForegroundColor;
           Console.ForegroundColor = ConsoleColor.Gray;

--- a/PaxConfig.cs
+++ b/PaxConfig.cs
@@ -74,7 +74,6 @@ namespace Pax
     public static List<NetworkInterfaceConfig> config { get { return configFile.interfaces; } }
 
     public static bool opt_verbose = false;
-    public static bool opt_no_default = false;
 
     public static string resolve_config_parameter (int port_no, string key) {
       NetworkInterfaceConfig port_conf;

--- a/Paxifax.cs
+++ b/Paxifax.cs
@@ -227,6 +227,8 @@ namespace Pax {
     }
   }
 
+  // This element does nothing to the packets it receives, and doesn't forward
+  // them on.
   public class Dropper : PacketMonitor {
     override public ForwardingDecision process_packet (int in_port, ref Packet packet)
     {

--- a/examples/nonsense_wiring.json
+++ b/examples/nonsense_wiring.json
@@ -5,5 +5,5 @@
       "lead_handler" : "SomeNameOfAHandlerThatDoesntExist10101010!"
     }
   ],
-  "reason": "This is used to test the -no-default command-line switch. I'd expect that '$ sudo mono ./Bin/Pax.exe examples/nonsense_wiring.json examples/Bin/Examples.dll' behaves fine but '$ sudo mono ./Bin/Pax.exe -no-default examples/nonsense_wiring.json examples/Bin/Examples.dll' will crash rather quickly with an unhandled exception related to 'SharpPcap.DeviceNotReadyException: No delegates assigned to OnPacketArrival, no where for captured packets to go.'."
+  "reason": "This is used to test whether Pax breaks when it attempts to wire a non-existing handler to an interface. I'd expect that '$ sudo mono ./Bin/Pax.exe examples/nonsense_wiring.json examples/Bin/Examples.dll' to break Pax when it attempts to load the element'."
 }


### PR DESCRIPTION
PR https://github.com/niksu/pax/pull/24 inadvertently made it easy to cover up a bad configuration, having Pax silently ignore it. I've changed this now to (i) complain more clearly about what the problem is when Pax encounters handler in the config that can't be matched to processors in the assembly, and (ii) stop Pax as before https://github.com/niksu/pax/pull/24